### PR TITLE
[Feature/til/vllm] Triton Inference Server Openai API 지원 Config file 추가

### DIFF
--- a/Til/vLLM-server/app/models/__init__.py
+++ b/Til/vLLM-server/app/models/__init__.py
@@ -1,1 +1,2 @@
-from .model import TILModels, get_til_model
+from .model import TILModel, get_til_model
+from .embedding import EmbeddingModel

--- a/Til/vLLM-server/app/models/embedding.py
+++ b/Til/vLLM-server/app/models/embedding.py
@@ -1,0 +1,38 @@
+from transformers import AutoTokenizer, AutoModel
+from typing import List
+import logging
+import torch
+
+logger = logging.getLogger(__name__)
+
+class EbeddingModelConfig:
+    EMBEDDING_MODEL: str = "BAAI/bge-m3"
+
+
+class EmbeddingModel:
+    def __init__(self, config: EbeddingModelConfig = EbeddingModelConfig()):
+        self.config = config
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._initialize_embedding()
+
+    def _initialize_embedding(self):
+        self.embedding_tokenizer = AutoTokenizer.from_pretrained(self.config.EMBEDDING_MODEL)
+        self.embedding_model = AutoModel.from_pretrained(self.config.EMBEDDING_MODEL).to(self.device)
+        self.embedding_model.eval()
+
+    async def get_embedding(self, text: str) -> List[float]:
+        try:
+            inputs = self.embedding_tokenizer(text, return_tensors="pt", truncation=True, max_length=1024)
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+            outputs = self.embedding_model(**inputs)
+            with torch.no_grad():
+                outputs = self.embedding_model(**inputs)
+                embeddings = outputs.last_hidden_state.mean(dim=1)  # mean pooling
+            return embeddings[0].tolist()
+        except Exception as e:
+            logger.error(f"임베딩 생성 실패: {e}")
+            raise
+
+    @property
+    def embedding_dimension(self) -> int:
+        return self.embedding_model.config.hidden_size

--- a/Til/vLLM-server/app/models/model.py
+++ b/Til/vLLM-server/app/models/model.py
@@ -1,7 +1,9 @@
 import uuid
 from functools import lru_cache
+from openai import AsyncOpenAI
 import logging
 import os
+
 from typing import Optional, List
 from dotenv import load_dotenv
 
@@ -13,86 +15,53 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 class ModelConfig:
-    GEMMA_PATH: str = os.getenv("GEMMA_MODEL_4B_PATH")
     EMBEDDING_MODEL: str = "BAAI/bge-m3"
-    
-    # VLLM 설정
-    TENSOR_PARALLEL_SIZE: int = 1
-    GPU_MEMORY_UTILIZATION: float = 0.95
-    MAX_NUM_SEQS: int = 25
-    MAX_MODEL_LEN: int = 4096
-    MAX_NUM_BATCHED_TOKENS: int = 4096
+    GEMMA_PATH: str = os.getenv("GEMMA_MODEL_4B_PATH")
+
 
 class TILModels:
     def __init__(self, config: ModelConfig = ModelConfig()):
         self.config = config
-        self._initialize_models()
-        
-    def _initialize_models(self):
-        """임베딩 모델과 LLM 초기화"""
-        try:
-            # 임베딩 모델 초기화
-            self.embedding_tokenizer = AutoTokenizer.from_pretrained(self.config.EMBEDDING_MODEL)
-            self.embedding_model = AutoModel.from_pretrained(self.config.EMBEDDING_MODEL)
-            self.embedding_model.eval()
-            
-            # VLLM 엔진 초기화
-            engine_args = AsyncEngineArgs(
-                model=self.config.GEMMA_PATH,
-                tensor_parallel_size=self.config.TENSOR_PARALLEL_SIZE,
-                gpu_memory_utilization=self.config.GPU_MEMORY_UTILIZATION,
-                max_num_seqs=self.config.MAX_NUM_SEQS,
-                max_model_len=self.config.MAX_MODEL_LEN,
-                max_num_batched_tokens=self.config.MAX_NUM_BATCHED_TOKENS
-            )
-            
-            self.llm = AsyncLLMEngine.from_engine_args(engine_args)
-            
-            logger.info("모델 초기화 완료")
-            
-        except Exception as e:
-            logger.error(f"모델 초기화 실패: {e}")
-            raise
-    
-    async def generate(self, prompt: str, sampling_params: Optional[SamplingParams] = None
-) -> str:
-        """LLM을 사용하여 텍스트 생성"""
-        try:
-            request_id = str(uuid.uuid4())
-            
-            async for output in self.llm.generate(
-                prompt=prompt,
-                sampling_params=sampling_params,
-                request_id=request_id
-            ):
-                text_chunk = output.outputs[0].text
-                full_text = text_chunk
 
-            if not full_text:
-                raise ValueError("생성된 출력이 없습니다.")
+        # vLLM 서버에 연결
+        self.client = AsyncOpenAI(
+            base_url="http://localhost:8001/v1",  # docker-compose에서 8000으로 열었을 가능성 높음
+            api_key=os.getenv("OPENAI_API_KEY")
+        )
 
-            return full_text
+        self._initialize_embedding()
 
-        except Exception as e:
-            logger.error(f"텍스트 생성 실패: {e}")
-            raise
-    
-    async def generate_til(self, prompt: str, sampling_params: Optional[SamplingParams] = None
-) -> str:
-        """TIL 생성을 위한 래퍼 메소드"""
+    def _initialize_embedding(self):
+        self.embedding_tokenizer = AutoTokenizer.from_pretrained(self.config.EMBEDDING_MODEL)
+        self.embedding_model = AutoModel.from_pretrained(self.config.EMBEDDING_MODEL)
+        self.embedding_model.eval()
+
+    async def generate(self, prompt: str, sampling_params: Optional[dict] = None,  extra_body: Optional[dict] = None) -> str:
+        messages = [{"role": "user", "content": prompt}]
         try:
-            result = await self.generate(prompt, sampling_params)
-            return result
+            request_payload = {
+                "model": "google/gemma-3-4b-it",  # 실제 model 이름 확인 필요(curl http://localhost:8001/v1/models)
+                "messages": messages,
+                "temperature": sampling_params.get("temperature", 0.1) if sampling_params else 0.7,
+                "max_tokens": sampling_params.get("max_tokens", 1024) if sampling_params else 1024,
+                "top_p": sampling_params.get("top_p", 0.95) if sampling_params else 0.95,
+            }
+
+            # extra_body가 있다면 추가
+            if extra_body:
+                request_payload["extra_body"] = extra_body
+
+            response = await self.client.chat.completions.create(**request_payload)
+            return response.choices[0].message.content.strip()
         except Exception as e:
-            logger.error(f"TIL 생성 실패: {e}")
+            logger.error(f"[vLLM generate] 오류 발생: {e}")
             return "[LLM 호출 실패]"
 
     async def get_embedding(self, text: str) -> List[float]:
-        """텍스트의 임베딩 벡터를 반환합니다."""
         try:
             inputs = self.embedding_tokenizer(text, return_tensors="pt", truncation=True, max_length=512)
             outputs = self.embedding_model(**inputs)
-            embeddings = outputs.last_hidden_state.mean(dim=1)  # [1, hidden_size]
+            embeddings = outputs.last_hidden_state.mean(dim=1)
             return embeddings[0].tolist()
         except Exception as e:
             logger.error(f"임베딩 생성 실패: {e}")
@@ -100,11 +69,9 @@ class TILModels:
 
     @property
     def embedding_dimension(self) -> int:
-        """임베딩 벡터의 차원을 반환합니다."""
         return self.embedding_model.config.hidden_size
 
-# 모델은 요청이 있을 때, 처음으로 로딩함 -> 그 이후에는 요청 즉시 생성
+
 @lru_cache()
 def get_til_model() -> TILModels:
-    """싱글톤 패턴으로 TILModel 인스턴스 제공"""
     return TILModels()

--- a/Til/vLLM-server/app/models/model.py
+++ b/Til/vLLM-server/app/models/model.py
@@ -1,25 +1,18 @@
-import uuid
 from functools import lru_cache
 from openai import AsyncOpenAI
 import logging
 import os
-
-from typing import Optional, List
+from typing import Optional
 from dotenv import load_dotenv
-
-from transformers import AutoTokenizer, AutoModel
-from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
 
 class ModelConfig:
-    EMBEDDING_MODEL: str = "BAAI/bge-m3"
     GEMMA_PATH: str = os.getenv("GEMMA_MODEL_4B_PATH")
 
-
-class TILModels:
+class TILModel:
     def __init__(self, config: ModelConfig = ModelConfig()):
         self.config = config
 
@@ -28,13 +21,6 @@ class TILModels:
             base_url="http://localhost:8001/v1",  # docker-compose에서 8000으로 열었을 가능성 높음
             api_key=os.getenv("OPENAI_API_KEY")
         )
-
-        self._initialize_embedding()
-
-    def _initialize_embedding(self):
-        self.embedding_tokenizer = AutoTokenizer.from_pretrained(self.config.EMBEDDING_MODEL)
-        self.embedding_model = AutoModel.from_pretrained(self.config.EMBEDDING_MODEL)
-        self.embedding_model.eval()
 
     async def generate(self, prompt: str, sampling_params: Optional[dict] = None,  extra_body: Optional[dict] = None) -> str:
         messages = [{"role": "user", "content": prompt}]
@@ -57,21 +43,6 @@ class TILModels:
             logger.error(f"[vLLM generate] 오류 발생: {e}")
             return "[LLM 호출 실패]"
 
-    async def get_embedding(self, text: str) -> List[float]:
-        try:
-            inputs = self.embedding_tokenizer(text, return_tensors="pt", truncation=True, max_length=512)
-            outputs = self.embedding_model(**inputs)
-            embeddings = outputs.last_hidden_state.mean(dim=1)
-            return embeddings[0].tolist()
-        except Exception as e:
-            logger.error(f"임베딩 생성 실패: {e}")
-            raise
-
-    @property
-    def embedding_dimension(self) -> int:
-        return self.embedding_model.config.hidden_size
-
-
 @lru_cache()
-def get_til_model() -> TILModels:
-    return TILModels()
+def get_til_model() -> TILModel:
+    return TILModel()

--- a/Til/vLLM-server/app/schemas/state_types.py
+++ b/Til/vLLM-server/app/schemas/state_types.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional, Annotated, Union
+from enum import Enum
 
 
 def merge_dicts(x: dict, y: dict) -> dict:
@@ -15,6 +16,22 @@ def merge_patch_summary_lists(x: list, y: list) -> list:
     if y is None:
         return x
     return x + y
+
+class keywords(str, Enum):
+    keyword1 = "keyword1"
+    keyword2 = "keyword2"
+    keyword3 = "keyword3"
+    keyword4 = "keyword4"
+    keyword5 = "keyword5"
+    keyword6 = "keyword6"
+    keyword7 = "keyword7"
+    keyword8 = "keyword8"
+    keyword9 = "keyword9"
+    keyword10 = "keyword10"
+
+
+class TILKeywordsModel(BaseModel):
+    keywords_list: List[str] = []
 
 
 class PatchModel(BaseModel):
@@ -38,7 +55,7 @@ class TilJsonModel(BaseModel):
     username: str
     date: str
     repo: str
-    keywords: Union[str, List[str]] #List[str]
+    keywords: TILKeywordsModel
     content: str
     vector: List[float]
 

--- a/Til/vLLM-server/notebook/Structured output vLLM.ipynb
+++ b/Til/vLLM-server/notebook/Structured output vLLM.ipynb
@@ -1,0 +1,535 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Python 기반 vLLM 서버 실행"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "import os\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "from sklearn.metrics.pairwise import cosine_similarity\n",
+    "\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "import numpy as np\n",
+    "\n",
+    "load_dotenv(dotenv_path=os.path.abspath(\"/home/a01088415234/1-team-YouTIL-ai/Til/vLLM-server/.env\"))\n",
+    "model_path = os.getenv(\"GEMMA_MODEL_4B_PATH\")\n",
+    "\n",
+    "# 1. 모델 로딩\n",
+    "model = SentenceTransformer(\"BAAI/bge-m3\", trust_remote_code=True)\n",
+    "model = model.to(\"cuda\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def start_vllm_server():\n",
+    "    subprocess.Popen([\n",
+    "        \"vllm\", \"serve\",\n",
+    "        model_path,\n",
+    "        \"--port\", \"8001\",\n",
+    "        \"--max-model-len\", \"4096\",\n",
+    "        \"--gpu-memory-utilization\", \"0.95\",\n",
+    "        \"--max-num-seqs\", \"50\",\n",
+    "        \"--max-num-batched-tokens\", \"4096\"\n",
+    "    ])\n",
+    "\n",
+    "start_vllm_server()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "OPENAI_API_KEY = os.getenv(\"OPENAI_API_KEY\")\n",
+    "\n",
+    "client = OpenAI(\n",
+    "    base_url=\"http://localhost:8001/v1\",\n",
+    "    api_key=OPENAI_API_KEY,  # 아무 값이나 사용 가능\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:22:30 [__init__.py:239] Automatically detected platform cuda.\n",
+      "INFO 05-30 06:22:31 [api_server.py:1034] vLLM API server version 0.8.3\n",
+      "INFO 05-30 06:22:31 [api_server.py:1035] args: Namespace(subparser='serve', model_tag='/home/a01088415234/models/gemma-3-4b-it/', config='', host=None, port=8001, uvicorn_log_level='info', disable_uvicorn_access_log=False, allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, chat_template_content_format='auto', response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, enable_ssl_refresh=False, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, enable_request_id_headers=False, enable_auto_tool_choice=False, tool_call_parser=None, tool_parser_plugin='', model='/home/a01088415234/models/gemma-3-4b-it/', task='auto', tokenizer=None, hf_config_path=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, allowed_local_media_path=None, download_dir=None, load_format='auto', config_format=<ConfigFormat.AUTO: 'auto'>, dtype='auto', kv_cache_dtype='auto', max_model_len=4096, guided_decoding_backend='xgrammar', logits_processor_pattern=None, model_impl='auto', distributed_executor_backend=None, pipeline_parallel_size=1, tensor_parallel_size=1, data_parallel_size=1, enable_expert_parallel=False, max_parallel_loading_workers=None, ray_workers_use_nsight=False, block_size=None, enable_prefix_caching=None, prefix_caching_hash_algo='builtin', disable_sliding_window=False, use_v2_block_manager=True, num_lookahead_slots=0, seed=None, swap_space=4, cpu_offload_gb=0, gpu_memory_utilization=0.95, num_gpu_blocks_override=None, max_num_batched_tokens=4096, max_num_partial_prefills=1, max_long_partial_prefills=1, long_prefill_token_threshold=0, max_num_seqs=50, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, hf_overrides=None, enforce_eager=False, max_seq_len_to_capture=8192, disable_custom_all_reduce=False, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config=None, limit_mm_per_prompt=None, mm_processor_kwargs=None, disable_mm_preprocessor_cache=False, enable_lora=False, enable_lora_bias=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', num_scheduler_steps=1, use_tqdm_on_load=True, multi_step_stream_outputs=True, scheduler_delay_factor=0.0, enable_chunked_prefill=None, speculative_config=None, model_loader_extra_config=None, ignore_patterns=[], preemption_mode=None, served_model_name=None, qlora_adapter_name_or_path=None, show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, disable_async_output_proc=False, scheduling_policy='fcfs', scheduler_cls='vllm.core.scheduler.Scheduler', override_neuron_config=None, override_pooler_config=None, compilation_config=None, kv_transfer_config=None, worker_cls='auto', worker_extension_cls='', generation_config='auto', override_generation_config=None, enable_sleep_mode=False, calculate_kv_scales=False, additional_config=None, enable_reasoning=False, reasoning_parser=None, disable_cascade_attn=False, disable_log_requests=False, max_log_len=None, disable_fastapi_docs=False, enable_prompt_tokens_details=False, enable_server_load_tracking=False, dispatch_function=<function ServeSubcommand.cmd at 0x7f61d0c83130>)\n",
+      "INFO 05-30 06:22:40 [config.py:600] This model supports multiple tasks: {'generate', 'embed', 'classify', 'score', 'reward'}. Defaulting to 'generate'.\n",
+      "INFO 05-30 06:22:40 [config.py:1780] Chunked prefill is enabled with max_num_batched_tokens=4096.\n",
+      "INFO 05-30 06:22:49 [__init__.py:239] Automatically detected platform cuda.\n",
+      "INFO 05-30 06:22:51 [core.py:61] Initializing a V1 LLM engine (v0.8.3) with config: model='/home/a01088415234/models/gemma-3-4b-it/', speculative_config=None, tokenizer='/home/a01088415234/models/gemma-3-4b-it/', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=/home/a01088415234/models/gemma-3-4b-it/, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={\"level\":3,\"custom_ops\":[\"none\"],\"splitting_ops\":[\"vllm.unified_attention\",\"vllm.unified_attention_with_output\"],\"use_inductor\":true,\"compile_sizes\":[],\"use_cudagraph\":true,\"cudagraph_num_of_warmups\":1,\"cudagraph_capture_sizes\":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],\"max_capture_size\":512}\n",
+      "WARNING 05-30 06:22:52 [utils.py:2413] Methods determine_num_available_blocks,device_config,get_cache_block_size_bytes,initialize_cache not implemented in <vllm.v1.worker.gpu_worker.Worker object at 0x7f9b55592cb0>\n",
+      "INFO 05-30 06:22:52 [parallel_state.py:957] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0\n",
+      "INFO 05-30 06:22:52 [cuda.py:221] Using Flash Attention backend on V1 engine.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:23:01 [gpu_model_runner.py:1258] Starting to load model /home/a01088415234/models/gemma-3-4b-it/...\n",
+      "INFO 05-30 06:23:01 [config.py:3334] cudagraph sizes specified by model runner [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 264, 272, 280, 288, 296, 304, 312, 320, 328, 336, 344, 352, 360, 368, 376, 384, 392, 400, 408, 416, 424, 432, 440, 448, 456, 464, 472, 480, 488, 496, 504, 512] is overridden by config [512, 384, 256, 128, 4, 2, 1, 392, 264, 136, 8, 400, 272, 144, 16, 408, 280, 152, 24, 416, 288, 160, 32, 424, 296, 168, 40, 432, 304, 176, 48, 440, 312, 184, 56, 448, 320, 192, 64, 456, 328, 200, 72, 464, 336, 208, 80, 472, 344, 216, 88, 120, 480, 352, 248, 224, 96, 488, 504, 360, 232, 104, 496, 368, 240, 112, 376]\n",
+      "WARNING 05-30 06:23:01 [topk_topp_sampler.py:69] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]\n",
+      "Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  1.04it/s]\n",
+      "Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:02<00:00,  1.22s/it]\n",
+      "Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:02<00:00,  1.18s/it]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:23:04 [loader.py:447] Loading weights took 2.43 seconds\n",
+      "INFO 05-30 06:23:04 [gpu_model_runner.py:1273] Model loading took 8.5833 GiB and 2.698817 seconds\n",
+      "INFO 05-30 06:23:04 [gpu_model_runner.py:1542] Encoder cache will be initialized with a budget of 4096 tokens, and profiled with 16 image items of the maximum feature size.\n",
+      "INFO 05-30 06:23:22 [backends.py:416] Using cache directory: /home/a01088415234/.cache/vllm/torch_compile_cache/7948162d1b/rank_0_0 for vLLM's torch.compile\n",
+      "INFO 05-30 06:23:22 [backends.py:426] Dynamo bytecode transform time: 15.36 s\n",
+      "INFO 05-30 06:23:23 [backends.py:115] Directly load the compiled graph for shape None from the cache\n",
+      "INFO 05-30 06:23:35 [monitor.py:33] torch.compile takes 15.36 s in total\n",
+      "INFO 05-30 06:23:36 [kv_cache_utils.py:578] GPU KV cache size: 57,680 tokens\n",
+      "INFO 05-30 06:23:36 [kv_cache_utils.py:581] Maximum concurrency for 4,096 tokens per request: 14.08x\n",
+      "INFO 05-30 06:24:06 [gpu_model_runner.py:1608] Graph capturing finished in 29 secs, took 0.55 GiB\n",
+      "INFO 05-30 06:24:06 [core.py:162] init engine (profile, create kv cache, warmup model) took 61.77 seconds\n",
+      "WARNING 05-30 06:24:06 [config.py:1088] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.\n",
+      "INFO 05-30 06:24:06 [serving_chat.py:117] Using default chat sampling params from model: {'top_k': 64, 'top_p': 0.95}\n",
+      "INFO 05-30 06:24:06 [serving_completion.py:61] Using default completion sampling params from model: {'top_k': 64, 'top_p': 0.95}\n",
+      "INFO 05-30 06:24:06 [api_server.py:1081] Starting vLLM API server on http://0.0.0.0:8001\n",
+      "INFO 05-30 06:24:06 [launcher.py:26] Available routes are:\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /openapi.json, Methods: HEAD, GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /docs, Methods: HEAD, GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /docs/oauth2-redirect, Methods: HEAD, GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /redoc, Methods: HEAD, GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /health, Methods: GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /load, Methods: GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /ping, Methods: POST, GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /tokenize, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /detokenize, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/models, Methods: GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /version, Methods: GET\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/chat/completions, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/completions, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/embeddings, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /pooling, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /score, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/score, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/audio/transcriptions, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /rerank, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v1/rerank, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /v2/rerank, Methods: POST\n",
+      "INFO 05-30 06:24:06 [launcher.py:34] Route: /invocations, Methods: POST\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:     Started server process [163626]\n",
+      "INFO:     Waiting for application startup.\n",
+      "INFO:     Application startup complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "til = \"\"\" # 📅 2024-09-22\n",
+    "### 📖 1. 오늘 배운 내용\n",
+    "오늘 학습 내용은 review controller 에서 user token 을 사용하는 방식으로 변경했습니다.  JWT 를 이용하여 사용자 id 를 가져오도록 구현했고, service layer 에서 사용자 id 를 활용해서 리뷰 생성을 진행합니다. 이는 보안 강화를 위해 중요한 부분이라고 생각합니다.\n",
+    "\n",
+    "### 📚 2. 개념 정리\n",
+    "* **JWT (JSON Web Token)** : JSON 객체 형태로 데이터를 인코딩하여 안전하게 전송하기 위한 표준 방식입니다. 유효 기간 설정, 서명 등을 통해 위변조 방지 기능을 제공하며, 토큰 자체에 사용자 정보를 담아보낼 수 있습니다.\n",
+    "* **Spring Security**: 자바 기반 웹 애플리케이션에서 보안을 담당하는 프레임워크입니다. 인증, 권한 부여 등의 역할을 수행하며, 다양한 보안 관련 기능을 제공합니다.\n",
+    "* **인증 (Authentication)**: 사용자가 누구인지 확인하는 프로세스입니다.\n",
+    "* **인가 (Authorization)**: 인증된 사용자의 접근 권한을 결정하는 프로세스입니다.\n",
+    "\n",
+    "### 🤔 3. 해당 개념이 필요한 이유\n",
+    "사용자 토큰을 이용하면 서버 측에서는 클라이언트로부터 받은 토큰만으로 사용자 정보를 확인할 수 있어, 매 요청마다 데이터베이스 조회 과정을 거치지 않아 성능 향상 효과가 있습니다. 또한, 토큰 기반 인증은 세션 기반 인증보다 확장성이 뛰어나며, 모바일 앱과의 통합에도 용이합니다. 특히, API Gateway를 통한 인증 로직 분리가 가능해져 전체 시스템의 복잡도를 낮출 수 있습니다.\n",
+    "\n",
+    "### 💡 4. 개념을 활용하는 방법\n",
+    "1.  클라이언트는 로그인 성공 후 JWT 토큰을 발급받습니다.\n",
+    "2.  토큰은 클라이언트에게 전달됩니다.\n",
+    "3.  서버는 HTTP Header의 Authorization 필드에 있는 토큰을 검증합니다.\n",
+    "4.  유효한 토큰이면 토큰 내부에 저장된 사용자 ID를 추출합니다.\n",
+    "5.  서비스 레이어는 추출된 사용자 ID를 사용하여 리퀘스트 처리합니다.\n",
+    "\n",
+    "### 🛠️ 5. 문제 해결 과정\n",
+    "- 기존 컨트롤러에서 직접 사용자 정보를 파라미터로 받던 방식 대신 JWT 토큰을 검증하여 사용자 ID를 얻는 방법을 적용했습니다.\n",
+    "- Spring Security 설정을 업데이트하여 JWT 토큰 검증을 활성화했습니다.\n",
+    "- Service Layer 의 메서드를 수정하여 User Id 를 받아 리뷰를 생성하도록 했습니다.\n",
+    "- JWT 라이브러리를 프로젝트에 추가하고, 토큰 디코딩 및 유효성 검사 코드를 구현했습니다.\n",
+    "\n",
+    "### ✍️ 6. 하루 회고\n",
+    "오늘 JWT 토큰 인증을 적용하면서 보안 취약점을 개선하고, 사용자 식별 정보를 보다 효율적으로 관리할 수 있게 되었습니다. 앞으로 더 많은 곳에서 JWT 토큰을 적극적으로 활용하여 시스템의 안정성과 보안 수준을 높일 계획입니다.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:24:14 [chat_utils.py:396] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.\n",
+      "INFO 05-30 06:24:14 [logger.py:39] Received request chatcmpl-dd14564361b442cd8dc4ecc7e16cbf06: prompt: '<bos><start_of_turn>user\\n해당 Til을 참고해서 내용과 관련된 핵심 개념 키워드를 추출해주세요. /n  # 📅 2024-09-22\\n### 📖 1. 오늘 배운 내용\\n오늘 학습 내용은 review controller 에서 user token 을 사용하는 방식으로 변경했습니다.  JWT 를 이용하여 사용자 id 를 가져오도록 구현했고, service layer 에서 사용자 id 를 활용해서 리뷰 생성을 진행합니다. 이는 보안 강화를 위해 중요한 부분이라고 생각합니다.\\n\\n### 📚 2. 개념 정리\\n* **JWT (JSON Web Token)** : JSON 객체 형태로 데이터를 인코딩하여 안전하게 전송하기 위한 표준 방식입니다. 유효 기간 설정, 서명 등을 통해 위변조 방지 기능을 제공하며, 토큰 자체에 사용자 정보를 담아보낼 수 있습니다.\\n* **Spring Security**: 자바 기반 웹 애플리케이션��서 보안을 담당하는 프레임워크입니다. 인증, 권한 부여 등의 역할을 수행하며, 다양한 보안 관련 기능을 제공합니다.\\n* **인증 (Authentication)**: 사용자가 누구인지 확인하는 프로세스입니다.\\n* **인가 (Authorization)**: 인증된 사용자의 접근 권한을 결정하는 프로세스입니다.\\n\\n### 🤔 3. 해당 개념이 필요한 이유\\n사용자 토큰을 이용하면 서버 측에서는 클라이언트로부터 받은 토큰만으로 사용자 정보를 확인할 수 있어, 매 요청마다 데이터베이스 조회 과정을 거치지 않아 성능 향상 효과가 있습니다. 또한, 토큰 기반 인증은 세션 기반 인증보다 확장성이 뛰어나며, 모바일 앱과의 통합에도 용이합니다. 특히, API Gateway를 통한 인증 로직 분리가 가능해져 전체 시스템의 복잡도를 낮출 수 있습니다.\\n\\n### 💡 4. 개념을 활용하는 방법\\n1.  클라이언트는 로그인 성공 후 JWT 토큰을 발급받습니다.\\n2.  토큰은 클라이언트에게 전달됩니다.\\n3.  서버는 HTTP Header의 Authorization 필드에 있는 토큰을 검증합니다.\\n4.  유효한 토큰이면 토큰 내부에 저장된 사용자 ID를 추출합니다.\\n5.  서비스 레이어는 추출된 사용자 ID를 사용하여 리퀘스트 처리합니다.\\n\\n### 🛠️ 5. 문제 해결 과정\\n- 기존 컨트롤러에서 직접 사용자 정보를 파라미터로 받던 방식 대신 JWT 토큰을 검증하여 사용자 ID를 얻는 방법을 적용했습니다.\\n- Spring Security 설정을 업데이트하여 JWT 토큰 검증을 활성화했습니다.\\n- Service Layer 의 메서드를 수정하여 User Id 를 받아 리뷰를 생성하도록 했습니다.\\n- JWT 라이브러리를 프로젝트에 추가하고, 토큰 디코딩 및 유효성 검사 코드를 구현했습니다.\\n\\n### ✍️ 6. 하루 회고\\n오늘 JWT 토큰 인증을 적용하면서 보안 취약점�� 개선하고, 사용자 식별 정보를 보다 효율적으로 관리할 수 있게 되었습니다. 앞으로 더 많은 곳에서 JWT 토큰을 적극적으로 활용하여 시스템의 안정성과 보안 수준을 높일 계획입니다.<end_of_turn>\\n<start_of_turn>model\\n', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=0.95, top_k=64, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=3446, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=GuidedDecodingParams(json={'properties': {'keywords_list': {'default': [], 'items': {'type': 'string'}, 'title': 'Keywords List', 'type': 'array'}}, 'title': 'CarDescription', 'type': 'object'}, regex=None, choice=None, grammar=None, json_object=None, backend=None, whitespace_pattern=None), extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.\n",
+      "INFO 05-30 06:24:14 [async_llm.py:228] Added request chatcmpl-dd14564361b442cd8dc4ecc7e16cbf06.\n",
+      "INFO 05-30 06:24:16 [loggers.py:87] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/torch/utils/cpp_extension.py:2059: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. \n",
+      "If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:     127.0.0.1:49314 - \"POST /v1/chat/completions HTTP/1.1\" 200 OK\n",
+      "{\n",
+      "  \"keywords_list\": [\n",
+      "    \"JWT (JSON Web Token)\",\n",
+      "    \"Spring Security\",\n",
+      "    \"인증 (Authentication)\",\n",
+      "    \"인가 (Authorization)\",\n",
+      "    \"토큰\",\n",
+      "    \"사용자 ID\",\n",
+      "    \"API Gateway\",\n",
+      "    \"보안\",\n",
+      "    \"세션 기반 인증\",\n",
+      "    \"토큰 검증\",\n",
+      "    \"토큰 디코딩\"\n",
+      "  ]\n",
+      "}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:24:26 [loggers.py:87] Engine 000: Avg prompt throughput: 65.0 tokens/s, Avg generation throughput: 9.5 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pydantic import BaseModel\n",
+    "from enum import Enum\n",
+    "from typing import List\n",
+    "\n",
+    "class keywords(str, Enum):\n",
+    "    keyword1 = \"keyword1\"\n",
+    "    keyword2 = \"keyword2\"\n",
+    "    keyword3 = \"keyword3\"\n",
+    "    keyword4 = \"keyword4\"\n",
+    "    keyword5 = \"keyword5\"\n",
+    "    keyword6 = \"keyword6\"\n",
+    "    keyword7 = \"keyword7\"\n",
+    "    keyword8 = \"keyword8\"\n",
+    "    keyword9 = \"keyword9\"\n",
+    "    keyword10 = \"keyword10\"\n",
+    "\n",
+    "\n",
+    "class CarDescription(BaseModel):\n",
+    "    keywords_list: List[str] = []\n",
+    "\n",
+    "\n",
+    "json_schema = CarDescription.model_json_schema()\n",
+    "\n",
+    "response = client.chat.completions.create(\n",
+    "    model=model_path,\n",
+    "    messages=[\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": f\"해당 Til을 참고해서 내용과 관련된 핵심 개념 키워드를 추출해주세요. /n {til}\",\n",
+    "        }\n",
+    "    ],\n",
+    "    extra_body={\"guided_json\": json_schema},\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(response.choices[0].message.content)\n",
+    "\n",
+    "# response_text = \"\"\n",
+    "# for chunk in stream:\n",
+    "#     delta = chunk.choices[0].delta\n",
+    "#     if \"content\" in delta:\n",
+    "#         print(delta[\"content\"])\n",
+    "#         response_text += delta[\"content\"]\n",
+    "        \n",
+    "# # 출력 결과\n",
+    "# print(response_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "keywords_list=['JWT (JSON Web Token)', 'Spring Security', '인증 (Authentication)', '인가 (Authorization)', '토큰', '사용자 ID', 'API Gateway', '보안', '세션 기반 인증', '토큰 검증', '토큰 디코딩']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/tmp/ipykernel_162319/3393043497.py:4: PydanticDeprecatedSince20: The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, otherwise load the data then use `model_validate` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/\n",
+      "  parsed = CarDescription.parse_raw(response.choices[0].message.content)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['JWT (JSON Web Token)',\n",
+       " 'Spring Security',\n",
+       " '인증 (Authentication)',\n",
+       " '인가 (Authorization)',\n",
+       " '토큰',\n",
+       " '사용자 ID',\n",
+       " 'API Gateway',\n",
+       " '보안',\n",
+       " '세션 기반 인증',\n",
+       " '토큰 검증',\n",
+       " '토큰 디코딩']"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:24:36 [loggers.py:87] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pydantic import ValidationError\n",
+    "\n",
+    "try:\n",
+    "    parsed = CarDescription.parse_raw(response.choices[0].message.content)\n",
+    "    print(parsed)\n",
+    "except ValidationError as e:\n",
+    "    print(\"❌ JSON 파싱 실패:\", e)\n",
+    "\n",
+    "parsed.keywords_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 51064 (\\N{HANGUL SYLLABLE IN}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 51613 (\\N{HANGUL SYLLABLE JEUNG}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 44032 (\\N{HANGUL SYLLABLE GA}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 53664 (\\N{HANGUL SYLLABLE TO}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 53360 (\\N{HANGUL SYLLABLE KEUN}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 49324 (\\N{HANGUL SYLLABLE SA}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 50857 (\\N{HANGUL SYLLABLE YONG}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 51088 (\\N{HANGUL SYLLABLE JA}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 48372 (\\N{HANGUL SYLLABLE BO}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 50504 (\\N{HANGUL SYLLABLE AN}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 49464 (\\N{HANGUL SYLLABLE SE}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 49496 (\\N{HANGUL SYLLABLE SYEON}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 44592 (\\N{HANGUL SYLLABLE GI}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 48152 (\\N{HANGUL SYLLABLE BAN}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 44160 (\\N{HANGUL SYLLABLE GEOM}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 46356 (\\N{HANGUL SYLLABLE DI}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 53076 (\\N{HANGUL SYLLABLE KO}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/var/tmp/ipykernel_162319/1887484165.py:35: UserWarning: Glyph 46377 (\\N{HANGUL SYLLABLE DING}) missing from font(s) DejaVu Sans.\n",
+      "  plt.tight_layout()\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 51064 (\\N{HANGUL SYLLABLE IN}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 51613 (\\N{HANGUL SYLLABLE JEUNG}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 44032 (\\N{HANGUL SYLLABLE GA}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 53664 (\\N{HANGUL SYLLABLE TO}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 53360 (\\N{HANGUL SYLLABLE KEUN}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 49324 (\\N{HANGUL SYLLABLE SA}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 50857 (\\N{HANGUL SYLLABLE YONG}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 51088 (\\N{HANGUL SYLLABLE JA}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 48372 (\\N{HANGUL SYLLABLE BO}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 50504 (\\N{HANGUL SYLLABLE AN}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 49464 (\\N{HANGUL SYLLABLE SE}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 49496 (\\N{HANGUL SYLLABLE SYEON}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 44592 (\\N{HANGUL SYLLABLE GI}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 48152 (\\N{HANGUL SYLLABLE BAN}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 44160 (\\N{HANGUL SYLLABLE GEOM}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 46356 (\\N{HANGUL SYLLABLE DI}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 53076 (\\N{HANGUL SYLLABLE KO}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n",
+      "/home/a01088415234/myenv/test/lib/python3.10/site-packages/IPython/core/pylabtools.py:170: UserWarning: Glyph 46377 (\\N{HANGUL SYLLABLE DING}) missing from font(s) DejaVu Sans.\n",
+      "  fig.canvas.print_figure(bytes_io, **kw)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA9kAAAMWCAYAAADlCkWLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAhQBJREFUeJzs3XlYVeXexvF7gwgyiwMgoKiZ5khqOaI4pOVIZs4DNpwc0zQrtUzNnCpDj5qn08BJIT3HzKzMJJOitElTU9OcyAnHQMABEdb7By87t4CiLtwI3891cel+1rOe9Vubtct7P2uwGIZhCAAAAAAA3DIHexcAAAAAAEBxQcgGAAAAAMAkhGwAAAAAAExCyAYAAAAAwCSEbAAAAAAATELIBgAAAADAJIRsAAAAAABMQsgGAAAAAMAkhGwAAAAAAExCyAYASJL27t2rDh06yMvLSxaLRatWrbJ3SXZjsVg0ZcoUe5dxxwgLC1NYWJi9y7CKioqSxWLRL7/8UujbioiIUHBw8HX7JSQkyGKxKCoqyto2ZcoUWSyWwivOBGlpaapYsaKio6OtbREREXJ3d7djVfb1wgsvqEmTJvYuA0ARRsgGUOz8/PPPGjlypOrUqSM3NzdVrlxZvXr10h9//JGrb1hYmCwWiywWixwcHOTp6amaNWtq4MCBio2NLfA2IyIirONYLBZ5enqqQYMGeuONN5Senp6r/9atWzVgwAAFBQXJ2dlZPj4+at++vd5//31lZmbm6p+cnCwXFxdZLBb9/vvvN/aGFNDgwYP122+/6dVXX9WSJUvUuHHjXH2ufL+u9ZMTUIODg9WlSxebMSwWi0aOHFko+3A75YSm119/3abdMAw99dRTBPU8BAcH53vMPPjgg/YuD3mYN2+ePDw81KdPH3uXUqguXLigxx9/XHXr1pWXl5fc3d3VoEEDzZs3TxkZGTZ9x4wZo23btmn16tV2qhZAUVfK3gUAgNlmz56t77//Xo8++qjq16+v48ePa8GCBWrYsKF++OEH1a1b16Z/YGCgZs6cKUk6d+6c9u3bp5UrV2rp0qXq1auXli5dKicnp+tu19nZWe+8846k7FD80Ucf6dlnn9XPP/+sZcuWWfu98847Gjp0qHx9fTVw4EDVqFFDqampWr9+vR5//HElJiZq4sSJNmP/73//k8VikZ+fn6KjozV9+vRbfZtsXLhwQZs2bdKkSZOuGYAnTZqkJ554wvr6559/1vz58zVx4kTdc8891vb69eubWt+dwjAMDR8+XG+//bZeeuklQnYeQkJCNG7cuFztlSpVskM19vXiiy/qhRdesHcZ+crIyNC8efP0zDPPyNHR0d7lFKoLFy5o586d6tSpk4KDg+Xg4KCNGzfqmWee0Y8//qiYmBhrXz8/P3Xv3l2vv/66unXrZseqARRVhGwAxc7YsWMVExOj0qVLW9t69+6tevXqadasWVq6dKlNfy8vLw0YMMCmbdasWXr66ae1aNEiBQcHa/bs2dfdbqlSpWzGGT58uJo0aaLly5dr7ty5qlSpkn744QcNHTpUzZo105o1a+Th4WHtP2bMGP3yyy/asWNHrrGXLl2qTp06qUqVKoqJiTE9ZJ86dUqS5O3tfc1+DzzwgM1rFxcXzZ8/Xw888ECROl3YXkaNGqXFixdr0qRJmjZtmr3LMc25c+fk5uZmylgBAQG5Pm8lValSpVSqVNH9p9hnn32mU6dOqVevXvYupdD5+Pjohx9+sGkbOnSovLy8tGDBAs2dO1d+fn7WZb169dKjjz6qAwcOqFq1are7XABFHKeLAyh2mjdvbhOwJalGjRqqU6dOgU+1dnR01Pz581W7dm0tWLBAZ8+eveE6HBwcrMEzISFBkjR16lRZLBZFR0fbBOwcjRs3VkREhE3boUOHFB8frz59+qhPnz46ePCgNm7cWOA6fv31Vz300EPy9PSUu7u72rVrZ/OPySlTpqhKlSqSpPHjx8tisRToGtPbbfv27YqIiFC1atXk4uIiPz8/PfbYYzpz5oxNv5zrXPft26eIiAh5e3vLy8tLQ4YM0fnz5236pqen65lnnlGFChXk4eGhbt266ciRIzdV3+jRo7Vw4UJNmDAh15cg6enpevnll3XXXXfJ2dlZQUFBeu6552wuJWjdurUaNGiQ59g1a9ZUx44dJUkNGzZUjx49bJbXq1dPFotF27dvt7YtX7481+UF1zsWpL+vZ/7mm280fPhwVaxYUYGBgdblb7/9tqpXr64yZcro/vvvV3x8/A2+U9eXc83voUOH1KVLF7m7uysgIEALFy6UJP32229q27at3NzcrF885eX8+fN66qmnVK5cOXl6emrQoEFKSkrK1e+LL75QaGio3Nzc5OHhoc6dO2vnzp25+q1atUp169aVi4uL6tatq48//jjP7SYnJysiIkJeXl7y9vbW4MGDlZycnKtfXtdk51xOkbMtZ2dn1alTR2vXrs21flxcnBo3biwXFxdVr15d//rXv/IcMzY2Vi1btpS3t7fc3d1Vs2bNXGfL5GXVqlUKDg5W9erV81x+4MABdezYUW5ubqpUqZKmTZsmwzBs+pw5c0YDBw6Up6en9b3Ytm1bruvTJWn37t3q2bOnfHx85OLiosaNGxf4lOyc/f7jjz80YMAAeXl5qUKFCnrppZdkGIYOHz6s7t27y9PTU35+fnrjjTcKNG7Ofwuv/v21b99ekvTJJ58UaBwAJQshG0CJYBiGTpw4ofLlyxd4HUdHR/Xt21fnz5/Xd999d1Pb3b9/vySpXLlyOn/+vNavX69WrVqpcuXKBR7jww8/lJubm7p06aL7779f1atXt7kJ0bXs3LlToaGh2rZtm5577jm99NJLOnjwoMLCwvTjjz9Kknr06KE333xTktS3b18tWbJEkZGRN7ajt0FsbKwOHDigIUOG6J///Kf69OmjZcuWqVOnTrn+YS9lzzSlpqZq5syZ6tWrl6KiojR16lSbPk888YQiIyPVoUMHzZo1S05OTurcufMN1/bMM89o/vz5ev755zVjxgybZVlZWerWrZtef/11de3aVf/85z8VHh6uN998U71797b2GzhwoLZv357rTIaff/7ZGhwkKTQ01OZ4/Ouvv7Rz5045ODjYBN74+HhVqFDBehp/QY6FKw0fPly7du3S5MmTrac0v/vuu3rqqafk5+enOXPmqEWLFurWrZsOHz5c4PcqIyNDp0+fzvVz4cIFm36ZmZl66KGHFBQUpDlz5ig4OFgjR45UVFSUHnzwQTVu3FizZ8+Wh4eHBg0apIMHD+ba1siRI/X7779rypQpGjRokKKjoxUeHm5zvCxZskSdO3eWu7u7Zs+erZdeekm7du1Sy5YtrV+OSdK6dev0yCOPyGKxaObMmQoPD9eQIUNy3VzNMAx1795dS5Ys0YABAzR9+nQdOXJEgwcPLvB79N1332n48OHq06eP5syZo4sXL+qRRx6x+ULp119/1YMPPqgzZ85o6tSpevzxxzVt2rRcNyzcuXOnunTpovT0dE2bNk1vvPGGunXrpu+///66dWzcuFENGzbMc1lmZqYefPBB+fr6as6cOWrUqJFefvllvfzyy9Y+WVlZ6tq1qz788EMNHjxYr776qhITE/N8L3bu3KmmTZvq999/1wsvvKA33nhDbm5uCg8Pz/fLjLz07t1bWVlZmjVrlpo0aaLp06crMjJSDzzwgAICAjR79mzdddddevbZZ/Xtt9/mWv/SpUs6ffq0Dh8+rI8//livv/66qlSporvuusumn5eXl6pXr16g9xFACWQAQAmwZMkSQ5Lx7rvv2rS3bt3aqFOnTr7rffzxx4YkY968edccf/DgwYabm5tx6tQp49SpU8a+ffuMGTNmGBaLxahfv75hGIaxbds2Q5IxevToG6q9Xr16Rv/+/a2vJ06caJQvX97IyMi47rrh4eFG6dKljf3791vbjh07Znh4eBitWrWyth08eNCQZLz22ms3VNv//vc/Q5KxYcOGPJdXqVLF6Ny5s02bJGPEiBE3tB3DMIzz58/navvwww8NSca3335rbXv55ZcNScZjjz1m0/fhhx82ypUrZ329detWQ5IxfPhwm379+vUzJBkvv/zyNevJec+qVKliSDLGjx+fZ78lS5YYDg4ORnx8vE374sWLDUnG999/bxiGYSQnJxsuLi7G888/b9Pv6aefNtzc3Iy0tDTDMP5+z3ft2mUYhmGsXr3acHZ2Nrp162b07t3bul79+vWNhx9+2Pq6oMfC+++/b0gyWrZsaVy+fNnafunSJaNixYpGSEiIkZ6ebm1/++23DUlG69atr/l+GYZhfa/y+pk5c6a13+DBgw1JxowZM6xtSUlJRpkyZQyLxWIsW7bM2r579+5cv6+cfWjUqJFx6dIla/ucOXMMScYnn3xiGIZhpKamGt7e3saTTz5pU+fx48cNLy8vm/aQkBDD39/fSE5OtratW7fOegzkWLVqlSHJmDNnjrXt8uXLRmhoqCHJeP/9963tOcfqlSQZpUuXNvbt22dty/lvxz//+U9rW9euXQ1XV1fj6NGj1ra9e/capUqVshnzzTffNCQZp06dMm5ERkaGYbFYjHHjxuValvP7GTVqlLUtKyvL6Ny5s1G6dGnrtj766CNDkhEZGWntl5mZabRt2zbXe9GuXTujXr16xsWLF23GbN68uVGjRo3r1pvzXv7jH/+wtl2+fNkIDAw0LBaLMWvWLGt7zrE0ePDgXOPk/Dcl56dx48bG9u3b89xmhw4djHvuuee6tQEoeZjJBlDs7d69WyNGjFCzZs1uaDZJkvUxNampqdfte+7cOVWoUEEVKlTQXXfdpYkTJ6pZs2bWWZiUlBRJyvM08fxs375dv/32m/r27Wtt69u3r06fPq0vv/zymutmZmZq3bp1Cg8Pt7lm0N/fX/369dN3331nrelOUKZMGevfL168qNOnT6tp06aSpC1btuTqP3ToUJvXoaGhOnPmjHWf16xZI0l6+umnbfqNGTPmhuo6ceKEJOnuu+/Oc/n//vc/3XPPPapVq5bNzG3btm0lSRs2bJCUPTPWvXt3ffjhh9aZ1szMTC1fvlzh4eHWa6JDQ0MlyToLFx8fr/vuu08PPPCAdSY7OTlZO3bssPa9mWPhySeftLnZ1S+//KKTJ09q6NChNpdj5JwWXVBNmjRRbGxsrp8rj/EcV95kz9vbWzVr1pSbm5vNNcI1a9aUt7e3Dhw4kGv9f/zjHzY3LRw2bJhKlSpl/d3HxsYqOTnZ+pnK+XF0dFSTJk2sv5vExERt3bpVgwcPttnXBx54QLVr17bZ5po1a1SqVCkNGzbM2ubo6KhRo0YV+D1q3769zSna9evXl6enp3UfMzMz9dVXXyk8PNzmhnF33XWXHnroIZuxcu6z8MknnygrK6vANfz1118yDENly5bNt8+VN0nMOc390qVL+uqrryRJa9eulZOTk5588klrPwcHB40YMSLXtr7++mvr2Sc5v4czZ86oY8eO2rt3r44ePVqguq88ZhwdHdW4cWMZhqHHH3/c2p5zLOV1zLRp00axsbH63//+p6FDh8rJyUnnzp3Lc1tly5bV6dOnC1QXgJKl6N5tAwBMcPz4cXXu3FleXl5asWLFDd8hNy0tTVLBgrGLi4s+/fRTSdl3Gq9atarNtayenp6SChbYcyxdulRubm6qVq2a9u3bZ91OcHCwoqOjr3lq86lTp3T+/HnVrFkz17J77rlHWVlZOnz4sOrUqVPgeuzpr7/+0tSpU7Vs2TKdPHnSZlle18xffUp+TlhISkqSp6en/vzzTzk4OOS63jSv9+tann/+ea1Zs0ZPPfWUvL291bNnT5vle/fu1e+//64KFSrkuf6V+zJo0CAtX75c8fHxatWqlb766iudOHFCAwcOtPbx9fVVjRo1FB8fr6eeekrx8fFq06aNWrVqpVGjRunAgQP6/ffflZWVZQ3ZN3MsVK1a1abfn3/+KSn7/gZXcnJyuqEbP5UvX956Peu1uLi45HrPvLy8FBgYmOuaYy8vrzyvtb66Vnd3d/n7+1tPA9+7d68kWb/wuFrOZza/fZeyj5crv+T5888/5e/vn+s50jdyXOV1OUnZsmWt+3jy5ElduHAh1ynMknK19e7dW++8846eeOIJvfDCC2rXrp169Oihnj17ysHh+nMtRh6XYkjZYfnq33vOF00572/Oe+Hq6nrNGvft2yfDMPTSSy/ppZdeynN7J0+elJ+fn/UmjTl8fHxsvvS5+r3z8vKSi4tLrkuFvLy8ct3PQcr+fPn6+kqSevbsqRkzZuiBBx7Q3r17bW58JmW/N0X9OecA7IOQDaDYOnv2rB566CElJycrPj7+ph4RlHN9bF7/mL2ao6PjNcPDXXfdpVKlSum3334r0LYNw9CHH36oc+fO5Zotk7L/0ZmWlpbrH/PFVa9evbRx40aNHz9eISEhcnd3V1ZWlh588ME8Z+jy+0Ilv9Bws9zd3fXFF1+oVatW6t+/vzw9PdWhQwfr8qysLNWrV09z587Nc/2goCDr3zt27ChfX18tXbpUrVq10tKlS+Xn55fruGrZsqXWr1+vCxcuaPPmzZo8ebLq1q0rb29vxcfH6/fff5e7u7vuvffem96vK88csIf8fn9m/l5zjpslS5bkClCS7HbnbzP3sUyZMvr222+1YcMGff7551q7dq2WL1+utm3bat26dfluy8fHRxaLJc8vL8yW83t49tlnrTf4u9pdd92lw4cP5/ryZ8OGDTZPNshrf27l/ezZs6cmTZqkTz75RE899ZTNsqSkpBu6zweAkoOQDaBYunjxorp27ao//vhDX331VZ4h9XoyMzMVExMjV1dXtWzZ8pZrcnV1Vdu2bfX111/r8OHDNuEqL998842OHDmiadOm2TyDWsr+x90//vEPrVq1Kt/HIVWoUEGurq7as2dPrmW7d++Wg4PDdWsoKpKSkrR+/XpNnTpVkydPtrbnzETejCpVqigrK0v79++3mWXM6/26nnLlymndunVq0aKFevToodjYWDVr1kySVL16dW3btk3t2rW77qyXo6Oj+vXrp6ioKM2ePVurVq3Kddq2lH3K+Pvvv69ly5YpMzNTzZs3l4ODg1q2bGkN2c2bN7euZ8axkHMH+r1799rM/GZkZOjgwYP53hndnvbu3as2bdpYX6elpSkxMVGdOnWSJOtZDBUrVrzmF2RX7vvVrn5Pq1SpovXr1+f6Auxmjqv8VKxYUS4uLtazW66UV5uDg4PatWundu3aae7cuZoxY4YmTZqkDRs25LvfpUqVUvXq1fO8oZyUHYwPHDhgc5nEH3/8IenvO3JXqVJFGzZs0Pnz521ms6+uMWdG3MnJ6Zq/BycnJ8XGxtq0FfZxl3NDvrzOlimqxz0A++OabADFTmZmpnr37q1Nmzbpf//7nzXs3OgYTz/9tH7//Xc9/fTT1tNGb9XLL78swzA0cOBA66noV9q8ebP+85//SPr7VPHx48erZ8+eNj9PPvmkatSocc27jDs6OqpDhw765JNPbO6SfOLECcXExKhly5am7VdhywmLV8883cpd0HOuXZ0/f74pYwYEBCg2NlZubm7q3Lmz9YyFXr166ejRo/r3v/+da50LFy7kut5z4MCBSkpK0lNPPaW0tLQ8v0TJOQ189uzZql+/vvU64dDQUK1fv16//PKLtY9kzrHQuHFjVahQQYsXL9alS5es7VFRUXk+nqooePvtt5WRkWF9/dZbb+ny5cvW333Hjh3l6empGTNm2PTLkXNqsr+/v0JCQvSf//zHJmzFxsZq165dNut06tRJly9f1ltvvWVty8zM1D//+U/T9ivnrJlVq1bp2LFj1vZ9+/bpiy++sOn7119/5Vo/JCREkmweIZeXZs2a5bp7+pUWLFhg/bthGFqwYIGcnJzUrl07Sdnvb0ZGhs2xn5WVZX0UW46KFSsqLCxM//rXv5SYmJhrOzm/BxcXF7Vv397m51rXjN+I06dP5zmz/c4770jKPv6vdPbsWe3fv1/Nmzc3ZfsAihdmsgEUO+PGjdPq1avVtWtX/fXXX1q6dKnN8qtDy9mzZ619zp8/r3379mnlypXav3+/+vTpo1deecW02po3b66FCxdq+PDhqlWrlgYOHKgaNWooNTVVcXFxWr16taZPn6709HR99NFHeuCBB+Ti4pLnWN26ddO8efN08uRJVaxYMc8+06dPtz4jd/jw4SpVqpT+9a9/KT09XXPmzDFtv27UL7/8kutZ0pIUFhaW51kDnp6eatWqlebMmaOMjAwFBARo3bp1+c6yFURISIj69u2rRYsW6ezZs2revLnWr1+f50xgQdWoUUNffvmlwsLC1LFjR3333XcaOHCg/vvf/2ro0KHasGGDWrRooczMTO3evVv//e9/9eWXX9r8A/7ee+9V3bp1rTdMy+sRSnfddZf8/Py0Z88emxtqtWrVSs8//7wk2YRs6daPBScnJ02fPl1PPfWU2rZtq969e+vgwYN6//33b+ia7KNHj+b6TErZp92Hh4cXeJyCuHTpktq1a6devXppz549WrRokVq2bKlu3bpJyj6u3nrrLQ0cOFANGzZUnz59VKFCBR06dEiff/65WrRoYQ2SM2fOVOfOndWyZUs99thj+uuvv/TPf/5TderUsfnCrGvXrmrRooVeeOEFJSQkqHbt2lq5cmWeM6G3YsqUKdazJ4YNG6bMzEwtWLBAdevW1datW639pk2bpm+//VadO3dWlSpVdPLkSS1atEiBgYHXPUMn51Fkf/zxR64b+7m4uGjt2rUaPHiwmjRpoi+++EKff/65Jk6caL2WPjw8XPfff7/GjRunffv2qVatWlq9erU1+F95ZsfChQvVsmVL1atXT08++aSqVaumEydOaNOmTTpy5Ii2bdtm0juXt6VLl2rx4sXWmwOmpqbqyy+/VGxsrLp27Zrruv2vvvrK+rg2AMjl9t/QHAAKV+vWrfN9TNDV/9m7uq+7u7tRo0YNY8CAAca6desKvM2cR3gV1ObNm41+/foZlSpVMpycnIyyZcsa7dq1M/7zn/8YmZmZ1kffXP3IsSvFxcUV6PFiW7ZsMTp27Gi4u7sbrq6uRps2bYyNGzfa9Lndj/DK7+eVV17Jd1tHjhwxHn74YcPb29vw8vIyHn30UePYsWO5Ht+U8yifqx9ZlPNYp4MHD1rbLly4YDz99NNGuXLlDDc3N6Nr167G4cOHb+gRXnm9Z/Hx8UaZMmWMqlWrGkePHjUuXbpkzJ4926hTp47h7OxslC1b1mjUqJExdepU4+zZs7nWz3nU1JWPsLrao48+akgyli9fbm27dOmS4erqapQuXdq4cOFCrnUKcizkvE8///xznttdtGiRUbVqVcPZ2dlo3Lix8e233xqtW7e+5Ud4XfkYrPw+T/k9cu/q4yxnH7755hvjH//4h1G2bFnD3d3d6N+/v3HmzJlc62/YsMHo2LGj4eXlZbi4uBjVq1c3IiIijF9++cWm30cffWTcc889hrOzs1G7dm1j5cqVxuDBg21qNwzDOHPmjDFw4EDD09PT8PLyMgYOHGj8+uuvBX6EV16PuKtSpUquR06tX7/euPfee43SpUsb1atXN9555x1j3LhxhouLi02f7t27G5UqVTJKly5tVKpUyejbt6/xxx9/5NrG1dLT043y5cvn+lzm/H72799vdOjQwXB1dTV8fX2Nl19+2cjMzLTpe+rUKaNfv36Gh4eH4eXlZURERBjff/+9IcnmUWyGYRj79+83Bg0aZPj5+RlOTk5GQECA0aVLF2PFihXXrTW/z31Bj6Wff/7ZePTRR43KlSsbzs7Ohpubm9GwYUNj7ty5eT4usXfv3kbLli2vWxeAksliGCbfAQYAANySefPm6ZlnnlFCQkKed5oG8hMeHq6dO3fe0v0KrvTKK6/o/fff1969e2/46Qz5WbVqlR5++GF99913atGihSlj3k7Hjx9X1apVtWzZMmayAeSJa7IBAChCDMPQu+++q9atWxOwcU05N+XKsXfvXq1Zs8bmbtu36plnnlFaWpqWLVt2U+tfXWPO9emenp55XgpxJ4iMjFS9evUI2ADyxTXZAAAUAefOndPq1au1YcMG/fbbb/rkk0/sXRKKuGrVqikiIkLVqlXTn3/+qbfeekulS5fWc889Z9o23N3dcz2X/kaMGjVKFy5cULNmzZSenq6VK1dq48aNmjFjht0fE3ezZs2aZe8SABRxnC4OAEARkJCQoKpVq8rb21vDhw/Xq6++au+SUMQNGTJEGzZs0PHjx+Xs7KxmzZppxowZRWqGOCYmRm+88Yb27dunixcv6q677tKwYcM0cuRIe5cGAIWGkA0AAAAAgEm4JhsAAAAAAJMQsgEAAAAAMAk3PpOUlZWlY8eOycPDQxaLxd7lAAAAAABuI8MwlJqaqkqVKsnB4dbmognZko4dO6agoCB7lwEAAAAAsKPDhw8rMDDwlsYgZEvy8PCQlP2Genp62qWGjIwMrVu3Th06dJCTk5NdagDsic8ASjKOf5RkHP8oyTj+i46UlBQFBQVZs+GtIGRL1lPEPT097RqyXV1d5enpyQcMJRKfAZRkHP8oyTj+UZJx/Bc9Zlw+zI3PAAAAAAAwCSEbAAAAAACTELIBAAAAADAJ12QDAAAAQDGVmZmpjIwMe5dhd05OTnJ0dLwt2yJkAwAAAEAxYxiGjh8/ruTkZHuXUmR4e3vLz8/PlJubXQshGwAAAACKmZyAXbFiRbm6uhZ6sCzKDMPQ+fPndfLkSUmSv79/oW6PkA0AAAAAxUhmZqY1YJcrV87e5RQJZcqUkSSdPHlSFStWLNRTx7nxGQAAAAAUIznXYLu6utq5kqIl5/0o7GvUCdkAAAAAUAyV5FPE83K73g9CNgAAAAAAJiFkAwAAAABgEkI2AAAAAMCuLBbLNX+mTJmihIQEWSwWbd26VZJyvS4quLs4AAAAACC3zEwpPl5KTJT8/aXQUKmQ7sqdmJho/fvy5cs1efJk7dmzx9rm7u6u06dPF8q2zcZMNgCUIHXq1NFnn31m7zJui4ceekiLFi2ydxkAANyZVq6UgoOlNm2kfv2y/wwOzm4vBH5+ftYfLy8vWSwWmzZ3d/dC2W5hIGQDQBG1Z88ede3aVeXLl5enp6dq1aql2bNn39KYO3fuVJcuXUyq0Nbly5c1ceJEBQcHy93dXf7+/urSpYtSU1MLZXvX88UXX2j48OGSpLi4OHl7e9ulDgAA7jgrV0o9e0pHjti2Hz2a3V5IQbu4IGQDQBHVuXNnNWjQQIcOHVJSUpI++ugjVatW7abGunz5sgzDMLlCW7NmzdK6deu0YcMGpaWladu2berRo0ehbjMvhmEoMzPztm8XAIBiITNTGj1ayuvfDTltY8Zk90OeCNkAUASdPn1a+/fv11NPPSVXV1c5OjqqTp06evTRR619goOD9eqrr6phw4by9PRUx44ddezYMetyi8WiBQsWqG7dunJzc1NaWpqCg4O1atUqSVJUVJRCQkL0yiuvqGLFivL19VVkZKR1/aysLL344ovy9fVVpUqVtHDhQnl7eysuLi7Pmn/44Qd1795dVatWlSRVrFhRjz32mDw8PKx9li1bpvr168vb21v33XefNm7caF126dIlTZ48WdWrV5eHh4fq1aunLVu2WPc1p25JWrVqlYKDg23ei5kzZ6pp06ZydXXVrl27FBYWpsjISJ05c0YPPfSQzp49K3d3d7m7uys+Pl6+vr659uWee+7R8uXLC/IrAgCgeIqPzz2DfSXDkA4fzu6HPBGyAaAIKleunGrWrKkhQ4bov//9r/788888+73zzjuKiYnR8ePH5efnpwEDBtgsj4mJ0bp165SSkiI3N7dc6+/cuVOurq46evSoli9frvHjx2v//v2SpPfff1/R0dGKj4/X/v37tWXLlmue+t2iRQstXLhQkZGR+uWXX3T58mWb5WvWrNGzzz6rqKgo/fXXX5owYYK6du2qM2fOSJJeeOEFrVmzRmvXrlVKSopWrFihcuXKFfg9i4qK0n/+8x+lpaWpZs2a1vZy5crpiy++kJeXl9LS0pSWlqbQ0FANHDhQUVFR1n6bNm3SiRMnFB4eXuBtAgBQ7FxxAzJT+pVAhGwAKIIsFovi4uLUoEEDTZ06VdWqVVPt2rUVGxtr02/YsGGqVauWXF1dNWfOHG3YsEFHrvj2+bnnnlOlSpXk7OwsB4fc/8kvX768xo0bJycnJ4WFhSk4ONj6GIyYmBiNGDFCd999t8qUKaNZs2YpKysr35qff/55TZ8+XZ9++qnCwsJUvnx5vfDCC9ZTtxcuXKjx48erYcOGcnBwUI8ePVSrVi2tWbNGhmHoX//6l+bOnasaNWrIYrGoZs2aqlKlSoHfs2HDhqlmzZpydHRU6dKlr9v/8ccf10cffaS0tDRJ2SG9X79+cnZ2LvA2AQAodvz9ze1XAhGyAaCI8vPz0xtvvKGdO3fq1KlTeuihh/Twww/rr7/+sva5MoT6+vrK2dlZR48etbZVrlz5mtvw9fW1ee3m5madrT527JiCgoKsyypUqCAXF5d8x3JwcNATTzyh9evXKzk5WTExMVq8eLHeffddSdnPspw4caK8vb2tP1u3btXRo0d16tQpnT9/XjVq1CjAO5O36+3r1e655x7VrVtXK1as0MWLF7V8+XI99thjN719AACKhdBQKTBQsljyXm6xSEFB2f2KiD179mjr1q02PxkZGXarh+dkA8AdwMfHR1OmTNHcuXN18OBB+fj4SJLNaeQnT55Uenq6AgICrG15zV4XVKVKlXT48GHr61OnTunixYsFWrdUqVLq1KmT2rVrp99++02SFBQUpFGjRmno0KG5+huGIVdXV+3bt0/+eXwz7u7urvPnz1tfJ+Zxitq19jW/ZY8//riioqLk7OysKlWqqGHDhtfdNwAAijVHR2nevOy7iFsstjdAywnekZGF9rzsm9GnT59cbYcPH1ZgYKAdqmEmGwCKpKSkJL344ovavXu3MjMzdf78ec2dO1c+Pj6qVauWtd+//vUv7dmzRxcuXNDzzz+vVq1amfY/lL59+2rRokXat2+fLly4oIkTJ14zyL755pv66quvlJaWJsMw9P333ysuLk7NmzeXJI0YMUKvvfaaNm/eLMMwdP78eX311Vc6cuSILBaLnnzySY0bN0779u2TYRjas2eP9UuEhg0b6sMPP9TFixd14MABLVy48Ib2xdfXV6mpqTp58qRNe+/evbV582bNmjWLWWwAAHL06CGtWCFd8cW9pOwZ7hUrspcXooiICCUnJ+dqDw4OlmEYCgkJsXmd14+9ArZEyAaAIql06dI6evSoOnXqJC8vL1WuXFnff/+9vvjiC5sbmD322GPq27evfH19dfToUUVHR5tWw2OPPaY+ffqoefPmql69ukJCQuTi4pLvNctubm6aOHGiAgIC5O3trSeffFKTJ09W3759JUldu3bVrFmz9OSTT6ps2bKqWrWq5s2bZ73Oe/bs2WrXrp3at28vT09PPfroo9ZT46dPn67k5GRVqFBB/fr106BBg25oX2rWrKnHH39ctWvXlre3t7777jtJkoeHhx599FHt3r1b/fv3v9m3CgCA4qdHDykhQdqwQYqJyf7z4MFCD9jFgcUo7Aen3gFSUlLk5eWls2fPytPT0y41ZGRkaM2aNerUqZOcnJzsUgNgT3wGblxwcLAiIyNv292wExMTValSJR05csTmlPQ73bRp07R9+3atWLHCbjVw/KMk4/hHSVZYx//Fixd18OBBVa1a9Zr3UylprvW+mJkJmckGgNsgM1OKi5M+/DD7z/+/4XaRdvnyZa1atUoZGRlKSkrSmDFj1Lx582IVsE+dOqV///vfGjZsmL1LAQAAxQQhGwAK2cqVUnCw1KaN1K9f9p/BwdntRZlhGJo1a5bKlSun6tWr69y5c4qJibF3WaZ59dVXFRwcrM6dO6tdu3b2LgcAABQT3F0cAArRypXZN+e8+sKco0ez22/l3iEJCQm3XN+1ODk56YcffijUbdjTpEmTNGnSJHuXAQAAihlmsgGgkGRmSqNH5w7Y0t9tY8bcGaeOAwCAO0/OzUWR7Xa9H8xkA0AhiY+XjhzJf7lhSIcPZ/cLC7ttZQEAgGKudOnScnBw0LFjx1ShQgWVLl1alpxnXJdAhmHo0qVLOnXqlBwcHFS6dOlC3R4hGwAKSWKiuf0AAAAKwsHBQVWrVlViYqKOHTtm73KKDFdXV1WuXFkODoV7QjchGwAKib+/uf0AAAAKqnTp0qpcubIuX76sTK5Nk6Ojo0qVKnVbZvQJ2QBQSEJDpcDA7Juc5XVdtsWSvTw09PbXBgAAij+LxSInJyeeQX+bceMzACgkjo7SvHnZf7/6S9Oc15GR2f0AAABQPBCyAaAQ9eiR/ZiugADb9sDAW3t8FwAAAIomThcHgELWo4fUvXv2XcQTE7OvwQ4NZQYbAACgOCJkA8Bt4OjIY7oAAABKAk4XBwAAAADAJIRsAAAAAABMQsgGAAAAAMAkhGwAAAAAAExCyAYAAAAAwCSEbAAAAAAATELIBgAAAADAJIRsAAAAAABMQsgGAAAAAMAkhGwAAAAAAExCyAYAAAAAwCSEbAAAAAAATELIBgAAAADAJIRsAAAAAABMQsgGAAAAAMAkhGwAAAAAAExCyAYAAAAAwCSEbAAAAAAATELIBgAAAADAJIRsAAAAAABMUsreBQAAio+oqCjNmDFDPj4+Nu2pqakyDEOenp427UlJSZowYYIiIiJuY5UAAACFh5ANADDVjBkz1LNnT5u28PBwXb58WZ999plN+6pVq5ScnHwbqwMAAChcnC4OAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJimTIXrhwoYKDg+Xi4qImTZrop59+KtB6y5Ytk8ViUXh4eOEWCAAAAABAHkrZu4CrLV++XGPHjtXixYvVpEkTRUZGqmPHjtqzZ48qVqyY73oJCQl69tlnFRoaehurBQBcbeLEiXr99ddt2lJTU2UYhpo2bWrTnpSUpAkTJtzO8gAAAApVkQvZc+fO1ZNPPqkhQ4ZIkhYvXqzPP/9c7733nl544YU818nMzFT//v01depUxcfHKzk5+TZWDADFV2amFB8vJSZK/v5SaKjk6Jh//4iICEVERNy2+gAAAIqaIhWyL126pM2bN9vMajg4OKh9+/batGlTvutNmzZNFStW1OOPP674+Pjrbic9PV3p6enW1ykpKZKkjIwMZWRk3MIe3Lyc7dpr+4C98Rkoej79VHr+eeno0b/bAgKk2bOlrl3tV1dxxPGPkozjHyUZx3/RYebvoEiF7NOnTyszM1O+vr427b6+vtq9e3ee63z33Xd69913tXXr1gJvZ+bMmZo6dWqu9nXr1snV1fWGajZbbGysXbcP2BufgaLD0VG66qxvqzVrbm8tJQXHP0oyjn+UZBz/9nf+/HnTxipSIftGpaamauDAgfr3v/+t8uXLF3i9CRMmaOzYsdbXKSkpCgoKUocOHeTp6VkYpV5XRkaGYmNj9cADD8jJyckuNQD2xGeg6MjMlOrVs53BvpLFkj2jvX37tU8dR8Fx/KMk4/hHScbxX3TknN1shiIVssuXLy9HR0edOHHCpv3EiRPy8/PL1X///v1KSEhQ1yvOW8zKypIklSpVSnv27FH16tVzrefs7CxnZ+dc7U5OTnY/uItCDYA98Rmwv++/l/btu3afvXulH36QwsJuS0klBsc/SjKOf5RkHP/2Z+b7X6Qe4VW6dGk1atRI69evt7ZlZWVp/fr1atasWa7+tWrV0m+//aatW7daf7p166Y2bdpo69atCgoKup3lA0CxkJhobj8AAICSpEjNZEvS2LFjNXjwYDVu3Fj333+/IiMjde7cOevdxgcNGqSAgADNnDlTLi4uqlu3rs363t7ekpSrHQBQMP7+5vYDAAAoSYpcyO7du7dOnTqlyZMn6/jx4woJCdHatWutN0M7dOiQHByK1AQ8ABQroaFSYGD2NdmGkXu5xZK9PDT09tcGAABQ1BW5kC1JI0eO1MiRI/NcFhcXd811o6KizC8IAEoQR0dp3jypZ8/sQH1l0LZYsv+MjOSmZwAAAHlhShgAkEuPHtKKFdl3Eb9SYGB2e48e9qkLAACgqCuSM9kAAPvr0UPq3l2Kj8++yZm/f/Yp4sxgAwAA5I+QDQDIl6Mjj+kCAAC4EZwuDgAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEmKZMheuHChgoOD5eLioiZNmuinn37Kt++///1vhYaGqmzZsipbtqzat29/zf4AAAAAABSWIheyly9frrFjx+rll1/Wli1b1KBBA3Xs2FEnT57Ms39cXJz69u2rDRs2aNOmTQoKClKHDh109OjR21w5AAAAAKCkK3Ihe+7cuXryySc1ZMgQ1a5dW4sXL5arq6vee++9PPtHR0dr+PDhCgkJUa1atfTOO+8oKytL69evv82VAwAAAABKulL2LuBKly5d0ubNmzVhwgRrm4ODg9q3b69NmzYVaIzz588rIyNDPj4++fZJT09Xenq69XVKSookKSMjQxkZGTdZ/a3J2a69tg/YG58BlGQc/yjJOP5RknH8Fx1m/g6KVMg+ffq0MjMz5evra9Pu6+ur3bt3F2iM559/XpUqVVL79u3z7TNz5kxNnTo1V/u6devk6up6Y0WbLDY21q7bB+yNzwBKMo5/lGQc/yjJOP7t7/z586aNVaRC9q2aNWuWli1bpri4OLm4uOTbb8KECRo7dqz1dUpKivVabk9Pz9tRai4ZGRmKjY3VAw88ICcnJ7vUANgTnwGUZBz/KMk4/lGScfwXHTlnN5uhSIXs8uXLy9HRUSdOnLBpP3HihPz8/K657uuvv65Zs2bpq6++Uv369a/Z19nZWc7OzrnanZyc7H5wF4UaAHviM4CSjOMfJRnHP0oyjn/7M/P9L1I3PitdurQaNWpkc9OynJuYNWvWLN/15syZo1deeUVr165V48aNb0epAAAAAADkUqRmsiVp7NixGjx4sBo3bqz7779fkZGROnfunIYMGSJJGjRokAICAjRz5kxJ0uzZszV58mTFxMQoODhYx48flyS5u7vL3d3dbvsBAAAAACh5ilzI7t27t06dOqXJkyfr+PHjCgkJ0dq1a603Qzt06JAcHP6egH/rrbd06dIl9ezZ02acl19+WVOmTLmdpQMAAAAASrgiF7IlaeTIkRo5cmSey+Li4mxeJyQkFH5BAAAAAAAUQJG6JhsAAAAAgDsZIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJOUsncBAAAAAABIUlRUlGbMmCEfHx+b9tTUVBmGIU9PT5v2pKQkTZgwQREREbexymsjZAMAAAAAiowZM2aoZ8+eNm3h4eG6fPmyPvvsM5v2VatWKTk5+TZWd32cLg4AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmKSUvQsAAAAAACDHxIkT9frrr9u0paamyjAMNW3a1KY9KSlJEyZMuJ3lXRchGwAAAABQKDIzpfh4KTFR8veXQkMlR8f8+0dERCgiIuK21VcYCNkAAAAAANOtXCmNHi0dOfJ3W2CgNG+e1KOH/eoqbFyTDQAAAAAw1cqVUs+etgFbko4ezW5fudI+dd0OhGwAAAAAgGkyM7NnsA0j97KctjFjsvsVR4RsAAAAAIBp4uNzz2BfyTCkw4ez+xVHhGwAAAAAgGkSE83td6chZAMAAAAATOPvb26/Ow0hGwAAAABgmtDQ7LuIWyx5L7dYpKCg7H7FESEbAAAAAGAaR8fsx3RJuYN2zuvIyGs/L/tORsgGAAAAAJiqRw9pxQopIMC2PTAwu704Pye7lL0LAAAAAAAUPz16SN27Z99FPDEx+xrs0NDiO4Odg5ANAAAAACgUjo5SWJi9q7i9OF0cAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTlLJ3AQAAAACAki0qKkozZsyQj4+PTXtqaqp27typ2rVry9PT02ZZUlKSJkyYoIiIiFse68yZM5Kk6Ohovfnmm/muWxCEbAAAAACA3c2YMUM9e/a0aQsPD5ckVatWTZ999pnNslWrVik5OdmUsWJiYtS/f//rrlsQhGwAAAAAdwR7z3bmNxZwJUI2AAAAgDuGPWc7rzUWkIMbnwEAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACbhEV4AAAAAAFNlZkrx8VJiouTvL4WGSo6O115n4sSJev31123aUlNTJUkHDhxQ06ZNbZblPLfcjLHOnDlToHULgpANAAAAADDNypXS6NHSkSN/twUGSvPmST165L1ORESEIiIi8h1z165dBd7+zYyVkpIiLy8v9e/fX8OGDSvwtvJCyAYAAABgNzc642nP2c5rjYVsK1dKPXtKhmHbfvRodvuKFfkH7eKCkA0AAADALm50xtPes524tszM7N/n1QFbym6zWKQxY6Tu3a9/6vidjBufAQAAALjtcmY8rwzY0t8znitX2qcu3Lz4+Ny/zysZhnT4cHa/4oyQDQAAAOC2ut6Mp5Q945mZeVvLwi1KTDS3352KkA0AAADgtmLGs3jy9ze3352KkA0AAADgtmLGs3gKDc2+pt5iyXu5xSIFBWX3K84I2QAAu3jsscdksVj0+++/27THxcXJYrHI3d1dHh4eqlKlil588UVlZWVJksLCwhQZGZnvuJmZmZo7d67q168vNzc3VaxYUU2bNtWCBQt0+fLlAtV2vW0AAG4NM57Fk6Nj9k3rpNxBO+d1ZGTxvumZRMgGANhBamqq/vvf/8rHx0fvvvturuVeXl5KS0tTamqqPvvsM/373//Os19e+vXrp/fee0/z58/X6dOndfz4cS1YsEA//fSTzp49a/auAABuAjOexVePHtmP6QoIsG0PDCwZj++SCNkAADtYvny53NzcNHv2bC1ZskQZGRn59q1Xr55CQ0O1ffv2644bFxenTz75RJ9++qnCwsJUpkwZOTg4qHHjxvrggw9Urlw5SdKvv/6qli1bysfHRxUqVFDfvn115swZSdK4ceMUHx+v559/Xu7u7nrooYckSWlpaRo5cqQqV66sihUratCgQdbQPmzYML3wwguSJMMwVKFCBfXp08daV6NGjfTRRx9JkubOnasaNWrIw8ND1atX14IFC6z9evbsqSlTptjs09ChQzVs2LDr7jsA3EmY8SzeevSQEhKkDRukmJjsPw8eLBkBWyJkAwDs4N1331X//v3Vp08fnTt3Tp9++mm+fbdt26Zvv/1WDRs2vO64X375pe6//35VrVr1mv0cHBw0a9YsnThxQjt27NDRo0etIfmNN95QaGioZs+erbS0NH3xxReSsk9v/+uvv7R9+3YdPHhQGRkZGjlypCSpTZs22rBhgyRp+/bt8vT01DfffCNJSkpK0vbt29WmTRtJUpUqVfT1118rJSVF77zzjsaPH6+NGzdKkoYMGaIPPvhAxv/fWvfixYtatmyZHnvssevuOwDcaZjxLN4cHaWwMKlv3+w/S9IXJoRsAMBttWvXLv3www8aPHiw3N3d9fDDD+c6Ffzs2bPy9vZW2bJl1atXL40aNUoRERHXHfv06dOqVKmSTVvNmjXl7e2tMmXKWMN8gwYN1LJlSzk5OcnX11djx45VXFxcvuOeOnVKH330kRYuXChvb2+5ublp2rRpWr58uTIzMxUWFqYtW7YoJSVFX3/9tR555BGVL19eu3btUlxcnOrWrSsfHx9J0iOPPKKgoCBZLBa1adNGHTt2tAbyBx98UOnp6dbXH3/8sQIDA3XfffcV9O0FgDtKSZ/xRPFUyt4FAABKlnfffVcNGjRQgwYNJEmDBw/Wgw8+qKNHjyrg/6czvLy8lJycfMNjly9fXnv27LFpy3kdHByszP9/4Oq+ffs0btw4/fzzz0pLS1NWVpacnJzyHTchIUFZWVm5ZsgdHBx0/PhxBQQEqGbNmoqPj9fXX3+t4cOH69KlS9qwYYN2796ttm3bWteJjo7WG2+8YR3z/PnzqlKliiTJ0dFRgwYNUlRUlMLCwhQVFcUsNoBiL2fGEygumMkGANw2GRkZWrJkif744w/5+fnJz89P/fv3V2ZmpqKiom55/AceeEA///yzEhISrtlv6NChCggI0K5du5SSkqKlS5daT9GWssPzlYKCguTg4KBjx44pOTnZ+nPx4kXrFwNt2rRRbGysNm3apNDQULVt21YbNmzQ119/bT1V/NChQxo8eLDmzJmjkydPKjk5WZ06dbLZ9mOPPaaPPvpIe/bs0TfffKMBAwbc8vsCAABuH0I2AOC2Wb16tVJSUrRlyxZt3bpVW7du1bZt2/TSSy/pvffeswmbN6Nt27bq3LmzunXrpm+++UYXLlxQVlaWfv31V6Wmplr7paSkyMPDQ56enjp8+LBee+01m3F8fX21f/9+62s/Pz+Fh4dr5MiROn36tCTp+PHj+vjjj6192rRpo/fff19333233N3d1bp1a61fv15//PGHWrVqJSn75mmGYahixYpycHDQmjVrtG7dOptt16hRQw0bNlTv3r310EMPqWLFirf0ngAAgNuLkA0AuG3effdd9e3bV7Vq1bLOZPv5+enpp5/WsWPHrDcPuxXLli3TwIEDNWLECJUrV07+/v4aOnSopk+frgcffFBS9h2+P/vsM3l6eqp79+565JFHbMYYM2aMvvrqK3l7e6tLly6SpKioKHl7e+u+++6Tp6enQkNDtXnzZus6YWFhSk1NtZ4a7uXlpbvvvluNGjWSp6enJKl27dqaNGmS2rZtq3Llymn58uXq1q1brn14/PHHtW3bNg0ZMuSW3w8AAHB7WYxbnTYoBlJSUuTl5aWzZ89a/yF0u2VkZGjNmjXq1KnTNa8LBIorPgMoya4+/r/99lv16tVLR44cUalS3D4FxRv//UdJxvFfdJiZCZnJBgCgCLl06ZLeeOMNPfnkkwRsAADuQIRsAMBNy8yU4uKkDz/M/vP/b96Nm/Ttt9+qbNmyOn36tMaPH2/vcgAAwE3gK3IAwE1ZuVIaPVo6cuTvtsBAad48nm96s1q1aqVz587ZuwwAAHALmMkGANywlSulnj1tA7YkHT2a3b5ypX3qAgAAsDdCNgDghmRmZs9g53XbzJy2MWM4dRwAAJRMhGwAwA2Jj889g30lw5AOH87uBwAAUNIQsgEANyQx0dx+AAAAxQkhGwBwQ/z9ze0HAABQnBCyAQA3JDQ0+y7iFkveyy0WKSgoux8AAEBJQ8gGANwQR8fsx3RJuYN2zuvIyOx+AAAAJQ0hGwBww3r0kFaskAICbNsDA7PbeU42AAAoqUrZuwAAwJ2pRw+pe/fsu4gnJmZfgx0aygw2AAAo2QjZAICb5ugohYXZuwoAAICig9PFAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwCSEbAAAAAACTELIBAAAAADAJIRsAAAAAAJMQsgEAAAAAMAkhGwAAAAAAkxCyAQAAAAAwyQ2F7AsXLui7777Trl27ci27ePGiPvjgA1OKWrhwoYKDg+Xi4qImTZrop59+umb///3vf6pVq5ZcXFxUr149rVmzxpQ6AAAAAAC4EQUO2X/88YfuuecetWrVSvXq1VPr1q2VmJhoXX727FkNGTLklgtavny5xo4dq5dffllbtmxRgwYN1LFjR508eTLP/hs3blTfvn31+OOP69dff1V4eLjCw8O1Y8eOW64FAAAAAIAbUeCQ/fzzz6tu3bo6efKk9uzZIw8PD7Vo0UKHDh0ytaC5c+fqySef1JAhQ1S7dm0tXrxYrq6ueu+99/LsP2/ePD344IMaP3687rnnHr3yyitq2LChFixYYGpdAAAAAABcT4FD9saNGzVz5kyVL19ed911lz799FN17NhRoaGhOnDggCnFXLp0SZs3b1b79u3/LtDBQe3bt9emTZvyXGfTpk02/SWpY8eO+fYHAAAAAKCwlCpoxwsXLqhUqb+7WywWvfXWWxo5cqRat26tmJiYWy7m9OnTyszMlK+vr027r6+vdu/enec6x48fz7P/8ePH891Oenq60tPTra9TUlIkSRkZGcrIyLjZ8m9JznbttX3A3vgMoCTj+EdJxvGPkozjv+gw83dQ4JBdq1Yt/fLLL7rnnnts2nNOy+7WrZtpRRW2mTNnaurUqbna161bJ1dXVztU9LfY2Fi7bh+wNz4DKMk4/lGScfyjJOP4t7/z58+bNlaBQ/bDDz+sDz/8UAMHDsy1bMGCBcrKytLixYtvqZjy5cvL0dFRJ06csGk/ceKE/Pz88lzHz8/vhvpL0oQJEzR27Fjr65SUFAUFBalDhw7y9PS8hT24eRkZGYqNjdUDDzwgJycnu9QA2BOfAZRkHP8oyTj+UZJx/BcdOWc3m6HAIXvChAmaMGFCvssXLVqkRYsW3VIxpUuXVqNGjbR+/XqFh4dLkrKysrR+/XqNHDkyz3WaNWum9evXa8yYMda22NhYNWvWLN/tODs7y9nZOVe7k5OT3Q/uolADYE98BlCScfyjJOP4R0nG8W9/Zr7/BQ7Zt8vYsWM1ePBgNW7cWPfff78iIyN17tw56+PBBg0apICAAM2cOVOSNHr0aLVu3VpvvPGGOnfurGXLlumXX37R22+/bc/dAAAAAACUQEUuZPfu3VunTp3S5MmTdfz4cYWEhGjt2rXWm5sdOnRIDg5/3xS9efPmiomJ0YsvvqiJEyeqRo0aWrVqlerWrWuvXQAAAAAAlFBFLmRL0siRI/M9PTwuLi5X26OPPqpHH320kKsCAAAAAODaCvycbAAAAAAAcG2mheysrCx99tlnZg0HAAAAAMAd55ZPF9+3b5/ee+89RUVF6dSpUzxIHQAAAABQYt3UTPaFCxf0wQcfqFWrVqpZs6Y2btyoyZMn68iRI2bXBwAAAADAHeOGZrJ//vlnvfPOO1q2bJmqV6+u/v37a+PGjVq0aJFq165dWDUCAAAAAHBHKHDIrl+/vlJSUtSvXz9t3LhRderUkSS98MILhVYcAAAAAAB3kgKfLr5nzx61atVKbdq0YdYaAAAAAIA8FHgm+8CBA4qKitKwYcN04cIF9e3bV/3795fFYinM+oASJyoqSjNmzJCPj49Ne2pqqnbu3KnatWvL09PTZllSUpImTJigiIiIO2KsvMYtW7askpOTNWPGDFkslgKNK+maNV0tLi5O4eHhSk5OliRFREQoJiZGzs7OcnBwkK+vr9q2bavnn39eVatWzbdmAAAAID8FDtkBAQGaNGmSJk2apK+//lrvvfeeWrRoocuXLysqKkpPPPGE7r777sKsFSgxZsyYoZ49e9q0hYeHS5KqVauW63F5q1atsgbHO2Wsq8ft3r271qxZo06dOsnJyanA416rpoIYPny4IiMjJUkHDx7Um2++qXvvvVebNm3SPffcU+BxAAAAAOkm7y7etm1bLV26VImJiVqwYIG+/vpr1apVS/Xr1ze7PgC4bapWrar58+eradOmevnll+1dDgAAAO5ANxWyc3h5eWn48OH65ZdftGXLFoWFhZlUFgDYT8+ePfXNN9/YuwwAAADcgQocsi9cuKDVq1crNTU117KUlBQdOnRIr732mqnFAYA9BAQE6K+//rJ3GQAAALgDFThkv/3225o3b548PDxyLfP09NT8+fP1zjvvmFocANjD0aNHc91MDQAAACiIAofs6OhojRkzJt/lY8aM0X/+8x8zagIAu1qxYgWXvwAAAOCmFPju4nv37lWDBg3yXV6/fn3t3bvXlKIAwB7+/PNPRUZG6ocfftCmTZvsXQ4AAADuQAWeyb58+bJOnTqV7/JTp07p8uXLphQFALfLokWL5OHhIU9PT7Vr107nzp3Tli1beHwXAAAAbkqBZ7Lr1Kmjr776So0aNcpz+bp161SnTh3TCgMAs4WFhdk8tzsqKkpRUVF2qwcAAADFT4FD9mOPPaaxY8eqTp066tKli82yTz/9VK+++qrmzp1reoFAcZCZKcXHS4mJkr+/FBoqOTrm33/ixIl6/fXXbdpy7ux/4MABNW3a1GZZUlKSJkyYUCTGMgwpNVXKyJDS05M0ZUreY1097muvvabk5GTNmDFDFoulwDVeqyYAAADgdrMYhmEUtPOAAQMUExOjWrVqqWbNmpKk3bt3648//lCvXr304YcfFlqhhSklJUVeXl46e/asPD097VJDRkaG1qxZo06dOsnJyckuNaBwrFwpjR4tHTnyd1tgoDRvntSjh/3qKgy3sq98BlCScfyjJOP4R0nG8V90mJkJC3xNtiQtXbpUy5YtU40aNfTHH39oz549qlmzpj788MM7NmADhWnlSqlnT9vQKUlHj2a3r1xpn7oKQ0naVwAAACA/BT5dPEevXr3Uq1evwqgFKFYyM7NndfM6V8QwJItFGjNG6t792qeO3wlK0r4CAAAA11LgmeysrCzNnj1bLVq00H333acXXnhBFy5cKMzagDtafHzuWd0rGYZ0+HB2vztdSdpXAAAA4FoKHLJfffVVTZw4Ue7u7goICNC8efM0YsSIwqwNuKMlJprbrygrSfsKAAAAXEuBQ/YHH3ygRYsW6csvv9SqVav06aefKjo6WllZWYVZH3DH8vc3t19RVpL2FQAAALiWAofsQ4cOqVOnTtbX7du3l8Vi0bFjxwqlMOBOFxqafWdtiyXv5RaLFBSU3e9OV5L2FQAAALiWAofsy5cvy8XFxabNyclJGRkZphcFFAeOjtmPrpJyh8+c15GRxeNGYCVpXwEAAIBrKfDdxQ3DUEREhJydna1tFy9e1NChQ+Xm5mZtW8lzegCrHj2kFSvyfnZ0ZGTxek52SdpXAAAAID8FDtmDBw/O1TZgwABTiwGKox49sh9dFR+ffeMvf//s06aL46xuSdpXAAAAIC8FDtnvv/9+YdYBFGuOjlJYmL2ruD1K0r4CAAAAVyvwNdkAAAAAAODaCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2cAtWLZsmXr16lWo2wgLC1NkZGShbuNK0dHRat68eaGMHR8fr8DAQFPGSkhIUK1atZSenm7KeAAAAIAZCNkoMaKionT33XeradOmNj916tSRJNWuXTvXspo1ayoqKirP8bKysjRx4kS99NJLuZa1bdtWZcqUUVJS0g3VGBERoTFjxtzort20uLg4eXt727T1799fGzduvOWxExISZLFYlJycbG0LDQ3VkSNHbnlsSQoODlazZs20ePFiU8YDAAAAzFDK3gUAt9OMGTPUs2dPm7bw8HBJUrVq1fTZZ5/ZLFu1apVNSLzSmjVr5OPjo3r16tm0HzhwQHFxcSpbtqyio6M1cuRI0+qHrcGDB+vJJ5/U6NGj7V0KAAAAIImZbOCmrV69Wm3bts3V/t577ykkJESjRo3Su+++a7Ps6pnq5ORkWSwWJSQkaP78+YqOjtaiRYvk7u5unWGXpBMnTqhjx47y8PBQw4YN9dtvv1mXpaWlaeTIkapcubIqVqyoQYMG6ezZs5L+nk1esmSJ7rrrLnl7eysiIkIZGRk6c+aMHnroIZ09e1bu7u5yd3dXfHy8oqKiFBISYh0/JSVFI0eOVJUqVeTp6an77rtPhw8fliTNnTtXNWrUkIeHh6pXr64FCxZY17v//vslSYGBgXJ3d1d0dHSumfPU1FT94x//kL+/vypXrqy33npL586du27tOVq0aKEjR47o999/L+ivDQAAAChUhGzgJm3dulW1atWyacvMzFRUVJQiIiI0aNAgbdu2TVu2bCnQeE8//bT69++v4cOHKy0tTTt37rQuW7JkiebMmaOkpCQ1btxYo0aNsi577LHH9Ndff2n79u06ePCgMjIycs2ef/HFF/r111+1a9curV+/XtHR0SpXrpy++OILeXl5KS0tTWlpaQoNDc1VV0REhPbt26dNmzYpOTlZb7/9tsqUKSNJqlKlir7++mulpKTonXfe0fjx4/X9999Lkn766SdJ0pEjR5SWlqb+/fvnGnv06NHat2+fduzYoS1btujIkSN69tlnr1t7DicnJ911113aunVrgd5jAAAAoLARsoGblJSUJE9PT5u2L7/8UidPnlS/fv1UrVo1tWjRItds9s0YMGCAGjRooFKlSmnw4MHavHmzJOnUqVP66KOPtHDhQnl7e8vNzU3Tpk3T8uXLlZmZaV1/8uTJ8vDwUKVKlfTggw9a17+eEydO6OOPP9bbb7+tSpUqycHBQffee6/Kly8vSXrkkUcUFBQki8WiNm3aqGPHjoqLiyvQ2FlZWYqOjtbMmTNVrlw5lS9fXgMHDtTSpUuVlZVV4No9PT1v+Np3AAAAoLAQsoGbVLZsWaWkpNi0vfvuu+rUqZM1hA4ePFgxMTG6ePHiLW3Lz8/P+nc3NzelpaVJyj6lOisrS1WrVpW3t7e8vb113333ycHBQcePH893/dTU1AJt988//5Szs7MqV66c5/Lo6Gg1bNhQPj4+8vb21po1a3T69OkCjX3q1CldunRJwcHB1jZfX1+lp6fbjHG92lNSUlS2bNkCbRMAAAAobNz4DLhJISEh2r17t/X1qVOn9Omnn8rZ2dkaDC9fvqzk5GR99NFH6t+/v9zd3XX+/HnrOomJiTZjOjjc2PdeQUFBcnBw0LFjx+Tq6ppreUJCwjXXv972qlSpovT0dB0+fFhBQUE2yw4dOqTBgwdr7dq1CgsLU6lSpRQeHi7DMAo0doUKFVS6dGklJCTI19dXknTy5Ek5OzurfPnyOnTo0DXXl6SMjAzt27fP5hpyAAAAwJ6YyQZuUteuXbVhwwbr6w8++EA+Pj7avXu3tm7dqq1bt2rHjh2KiIiwnjLesGFDffnll0pMTFRqaqqmTp1qM6avr68OHDhgDarX4+fnp/DwcI0cOdI6+3v8+HF9/PHHBVrf19dXqampOnnyZL7Lu3fvrqFDhyoxMVFZWVn69ddfdebMGaWlpckwDFWsWFEODg5as2aN1q1bZ123QoUKcnBw0P79+/Mc28HBQf369dOkSZP0119/6cyZM1q6dKn69+9f4C8bNm7cqICAAN1zzz0F6g8AAAAUNkI2cJM6deqk06dPa8eOHZKyTxUfNmyYAgIC5OfnZ/0ZN26c4uLitH//fg0YMECtW7dWrVq1FBISos6dO9uM+cQTT+jo0aPy8fFR/fr1C1RHVFSU9TRxT09PhYaGFvia65o1a+rxxx9X7dq15e3tre+++y5Xn//85z8KCgpS48aN5e3traFDh+rChQuqXbu2Jk2apLZt26pcuXJavny5unXrZl2vTJkyevnll/XQQw/J29tbMTExucaeN2+egoODVbt2bYWEhMjPz0+vvfZagWqXsr/YGDFiRIH7AwAAAIXNYhR0yqwYS0lJkZeXl86ePZvrRla3S0ZGhtasWaNOnTrJycnJLjUUd1FRUXJ3d8/zOdmrVq1Sly5d8n1OdkRERJ5jfvjhh1q1apWWL19eWGWXGDf6Gfjzzz/14IMPauvWrXJ2dr4NFQKFh/8HoCTj+EdJxvFfdJiZCbkmGyXKxIkT9frrr9u05dxI68CBA2ratKnNsqSkJE2YMCHf8fr27au+ffuaXyiuq0qVKjwfGwAAAEUOIRt3rMxMKT5eSkyU/P2l0FDJ0TH//hEREfnOSEvSrl27zC8SAAAAQIlCyMYdaeVKafRo6ciRv9sCA6V586QePexXFwAAAICSjRuf4Y6zcqXUs6dtwJako0ez21eutE9dAAAAAEDIxh0lMzN7Bjuv2/XltI0Zk90PAAAAAG43QjbuKPHxuWewr2QY0uHD2f0AAAAA4HYjZOOOkphobj8AAAAAMBMhG3cUf39z+wEAAACAmQjZKJBly5apV69ehbqNsLAwRUZGXrNPaGj2XcQtlryXWyxSUFB2v0OHDsnd3V1nz541vdYZM2aY9nzs6Oho9e/f35SxAAAAANgXIbsYioqK0t13362mTZva/NSpU0eSVLt27VzLatasqaioqDzHy8rK0sSJE/XSSy/lWta2bVuVKVNGSUlJN1RjRESExowZc6O7JkfH7Md0SbmDds7ryMjsfpUrV1ZaWpq8vLxueDtXioqKUkhIiE3bxIkT9eGHH97SuDn69u2rn376Sb/++qsp4wEAAACwH0J2MTVjxgz98MMPNj81atSQJFWrVi3XstmzZ+c71po1a+Tj46N69erZtB84cEBxcXFydXVVdHR0oe7PlXr0kFaskAICbNsDA7Pbe/SQMjIybls9t8rBwUH9+/fXokWL7F0KAAAAgFtEyMZ1rV69Wm3bts3V/t577ykkJESjRo3Su+++a7Ps6pnq5ORkWSwWJSQkaP78+YqOjtaiRYvk7u5unWGXpBMnTqhjx47y8PBQw4YN9dtvv9ks69WrlypUqKAxYyprwIBJ+uqry4qJkd58M04pKd46ceItVa5cWc2bN1dCQoIsFouSk5N18uRJubu72/xYLBbFxcVJkgYMGKBKlSrJ09NTjRo10oYNGyRJv/76q4YOHarffvvNut6hQ4c0ZcoUhYeHW2vbt2+fOnbsKB8fH1WvXt3mtPecmfBXXnlFFStWlK+vb67T4tu1a6dPP/30Bn8zAAAAAIoaQjaua+vWrapVq5ZNW2ZmpqKiohQREaFBgwZp27Zt2rJlS4HGe/rpp9W/f38NHz5caWlp2rlzp3XZkiVLNGfOHCUlJalx48YaNWqUdVm/fv3k5OSkgwcPKj4+XqtXr9KPP85R375SSIiUmpqqbdu2affu3frmm29stlmxYkWlpaVZf1544QXVqVNHDRs2lJQdcn///XedOXNGffr0Uc+ePZWamqp7771XixcvVr169azrVq5c2Wbsy5cvq0uXLmrQoIGOHTumjz/+WHPmzFFMTIy1z86dO+Xq6qqjR49q+fLlGj9+vPbv329dXrt2bZ04cUKJ3BYdAAAAuKMRsnFdSUlJ8vT0tGn78ssvdfLkSfXr10/VqlVTixYtcs1m34wBAwaoQYMGKlWqlAYPHqzNmzdLko4ePaqvv/5ac+fOlbu7u6pUqaJJkybZXEeelZWlWbNmydXVVa6urvlu47///a8WLlyozz77zLpfQ4YMkZeXl5ycnDR+/HhlZWVp+/btBar5xx9/VGJioqZPny4XFxfVr19fI0eOtKmtfPnyGjdunJycnBQWFqbg4GBt3brVujynjhu9th0AAABA0ULIxnWVLVtWKSkpNm3vvvuuOnXqpPLly0uSBg8erJiYGF28ePGWtuXn52f9u5ubm9LS0iRJR44ckYuLi3x9fa3Lq1WrpiNHjlhfe3h4yNvb+5rj//DDDxo6dKg+/vhjBQcHS8oO55MmTVKNGjXk6ekpb29vnT17VqdPny5QzUeOHFGlSpVUunTpfGu7su6cfUtNTbW+znl/y5YtW6BtAgAAACiaStm7ABR9ISEh2r17t/X1qVOn9Omnn8rZ2dkaii9fvqzk5GR99NFH6t+/v9zd3XX+/HnrOlefBu3gcGPf7wQGBurixYs6ceKENbAmJCQoMDCwwGMmJCQoPDxcixcvVtOmTa3tMTExiomJ0ZdffqkaNWrIYrGobNmyMgyjQOMGBgbq2LFjysjIkJOTU561Xc+uXbvk6+srfx7wDQAAANzRmMnGdXXt2tV6IzBJ+uCDD+Tj46Pdu3dr69at2rp1q3bs2KGIiAjrKeMNGzbUl19+qcTERKWmpmrq1Kk2Y/r6+urAgQPWIHs9AQEBatOmjZ599lmdO3dOhw4d0quvvqrBgwcXaP2UlBR16dJFo0aNyvW875SUFJUuXVrly5fXpUuXNG3aNJtZZl9fXyUmJurChQt5jn3//ffL19dXkydPVnp6unbs2KF//vOfBa5Nkr7++mt17ty5wP0BAAAAFE2EbFxXp06ddPr0ae3YsUNS9qniw4YNU0BAgPz8/Kw/48aNU1xcnPbv368BAwaodevWqlWrlkJCQnIFyCeeeEJHjx6Vj4+P6tevX6A6YmJidOHCBVWpUkUtWrRQ586d9dxzzxVo3S1btmjnzp2aOXOmzR3G4+PjNXjwYNWpU0dVqlRRtWrVVKZMGZtZ6LZt26pp06YKCAiQt7e3Dh06ZDO2k5OTPvvsM23evFl+fn7q1q2bxo4dq379+hWotqysLEVHR2vEiBEF6g8AAACg6OJ0cVyXo6OjZsyYoVdeeUXLly/Xrl278uxXt25dZWVlWV9/8MEHNssHDhxo/Xv16tWtNzXLkfM4rRwhISE2M91+fn5asWJFntsOCwtTcnKyTVtwcLB1/bCwsGvOmq9cudLm9fjx461/d3Jy0ieffGKzfMqUKTav7777bq1bty7PsSMiIhQREWHTduVNz5YtW6b77rvPeqdzAAAAAHcuQvYdIDNTio+XEhMlf38pNFRydLz2OhMnTtTrr79u05ZzCvSBAwdsrkmWsu9qPWHChHzH69u3r/r27XtzO4Br6tevX4FnvQEAAAAUbYTsIm7lSmn0aOmKG1UrMFCaN0/q0SPvdfKaOb1SfjPRAAAAAIBbwzXZRdjKlVLPnrYBW5KOHs1uv+oMZwAAAACAnRGyi6jMzOwZ7LwuI85pGzMmux8AAAAAoGggZBdR8fG5Z7CvZBjS4cPZ/QAAAAAARQMhu4hKTDS3HwAAAACg8BGyiyh/f3P7AQAAAAAKHyG7iAoNzb6LuMWS93KLRQoKyu4HAAAAACgaCNlFlKNj9mO6pNxBO+d1ZOT1n5cNAAAAALh9CNlFWI8e0ooVUkCAbXtgYHZ7fs/JBgAAAADYRyl7F4Br69FD6t49+y7iiYnZ12CHhjKDDQAAAABFESH7DuDoKIWF2bsKAAAAAMD1cLo4AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmKVIh2zAMTZ48Wf7+/ipTpozat2+vvXv3XnOdmTNn6r777pOHh4cqVqyo8PBw7dmz5zZVDAAAAADA34pUyJ4zZ47mz5+vxYsX68cff5Sbm5s6duyoixcv5rvON998oxEjRuiHH35QbGysMjIy1KFDB507d+42Vg4AAAAAgFTK3gXkMAxDkZGRevHFF9W9e3dJ0gcffCBfX1+tWrVKffr0yXO9tWvX2ryOiopSxYoVtXnzZrVq1arQ6wYAAAAAIEeRCdkHDx7U8ePH1b59e2ubl5eXmjRpok2bNuUbsq929uxZSZKPj0++fdLT05Wenm59nZKSIknKyMhQRkbGzZR/y3K2a6/tA/bGZwAlGcc/SjKOf5RkHP9Fh5m/A4thGIZpo92CjRs3qkWLFjp27Jj8/f2t7b169ZLFYtHy5cuvO0ZWVpa6deum5ORkfffdd/n2mzJliqZOnZqrPSYmRq6urje3AwAAAACAO9L58+fVr18/nT17Vp6enrc0lt1msqOjo/XUU09ZX3/++ee3POaIESO0Y8eOawZsSZowYYLGjh1rfZ2SkqKgoCB16NDhlt/Qm5WRkaHY2Fg98MADcnJysksNgD3xGUBJxvGPkozjHyUZx3/RkXN2sxnsFrK7deumJk2aWF/nnL594sQJm5nsEydOKCQk5LrjjRw5Up999pm+/fZbBQYGXrOvs7OznJ2dc7U7OTnZ/eAuCjUA9sRnACUZxz9KMo5/lGQc//Zn5vtvt5Dt4eEhDw8P62vDMOTn56f169dbQ3VKSop+/PFHDRs2LN9xDMPQqFGj9PHHHysuLk5Vq1Yt7NIBAAAAAMhTkXmEl8Vi0ZgxYzR9+nStXr1av/32mwYNGqRKlSopPDzc2q9du3ZasGCB9fWIESO0dOlSxcTEyMPDQ8ePH9fx48d14cIFO+wFAAAAAKAkKzJ3F5ek5557TufOndM//vEPJScnq2XLllq7dq1cXFysffbv36/Tp09bX7/11luSpLCwMJux3n//fUVERNyOsgEAAAAAkFTEQrbFYtG0adM0bdq0fPskJCTYvC4iN0cHAAAAAKDonC4OAAAAAMCdjpANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmKSUvQsAAAC4o2VmSvHxUmKi5O8vhYZKjo72rgoAYCeEbAAAgJu1cqU0erR05MjfbYGB0rx5Uo8e9qsLAGA3nC4OAABwM1aulHr2tA3YknT0aHb7ypX2qQsAYFeEbAAAgBuVmZk9g20YuZfltI0Zk90PAFCiELIBAABuVHx87hnsKxmGdPhwdj8AQIlCyAYAALhRiYnm9gMAFBuEbAAAgBvl729uPwBAsUHIBgAAuFGhodl3EbdY8l5usUhBQdn9AAAlCiEbAADgRjk6Zj+mS8odtHNeR0byvGwAKIEI2QAAADejRw9pxQopIMC2PTAwu53nZANAiVTK3gUAAADcsXr0kLp3z76LeGJi9jXYoaHMYANACUbIBgAAuBWOjlJYmL2rAAAUEZwuDgAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJCNkAAAAAAJiEkA0AAAAAgEkI2QAAAAAAmISQDQAAAACASQjZAAAAAACYhJANAAAAAIBJilTINgxDkydPlr+/v8qUKaP27dtr7969BV5/1qxZslgsGjNmTOEVCQAAAABAPopUyJ4zZ47mz5+vxYsX68cff5Sbm5s6duyoixcvXnfdn3/+Wf/6179Uv37921ApAAAAAAC5FZmQbRiGIiMj9eKLL6p79+6qX7++PvjgAx07dkyrVq265rppaWnq37+//v3vf6ts2bK3p2AAAAAAAK5Syt4F5Dh48KCOHz+u9u3bW9u8vLzUpEkTbdq0SX369Ml33REjRqhz585q3769pk+fft1tpaenKz093fo6JSVFkpSRkaGMjIxb2Iubl7Nde20fsDc+AyjJOP5RknH8oyTj+C86zPwdFJmQffz4cUmSr6+vTbuvr691WV6WLVumLVu26Oeffy7wtmbOnKmpU6fmal+3bp1cXV0LPE5hiI2Ntev2AXvjM4CSjOMfJRnHP0oyjn/7O3/+vGlj2S1kR0dH66mnnrK+/vzzz294jMOHD2v06NGKjY2Vi4tLgdebMGGCxo4da32dkpKioKAgdejQQZ6enjdchxkyMjIUGxurBx54QE5OTnapAbAnPgMoyTj+UZJx/KMk4/gvOnLObjaD3UJ2t27d1KRJE+vrnNO3T5w4IX9/f2v7iRMnFBISkucYmzdv1smTJ9WwYUNrW2Zmpr799lstWLBA6enpcnR0zLWes7OznJ2dc7U7OTnZ/eAuCjUA9sRnACUZxz9KMo5/lGQc//Zn5vtvt5Dt4eEhDw8P62vDMOTn56f169dbQ3VKSop+/PFHDRs2LM8x2rVrp99++82mbciQIapVq5aef/75PAM2AAAAAACFpchck53zfOvp06erRo0aqlq1ql566SVVqlRJ4eHh1n7t2rXTww8/rJEjR8rDw0N169a1GcfNzU3lypXL1Q4AAAAAQGErMiFbkp577jmdO3dO//jHP5ScnKyWLVtq7dq1Ntdb79+/X6dPn7ZjlQAAAAAA5K1IhWyLxaJp06Zp2rRp+fZJSEi45hhxcXHmFgUAAAAAQAE52LsAAAAAAACKC0I2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAAAAAGASQjYAAAAAACYhZAMAAAAAYBJCNgAAAAAAJiFkAwAAAABgEkI2AAAAAAAmIWQDAADAFEOHDtWiRYvsXUahs1gs2rp1a6FuIzg4WKtWrTJ93OjoaPXv39/0cQH8jZANAABQTIWFhSkyMlJ169bV4sWLre3nz5+Xs7OzIiIibPo3btxYb7zxhtzd3a0/jo6OcnZ2tr5+6KGH8tzWvn379Pnnn+uJJ56QJCUkJMhisSg5OVmSlJqaquHDhysgIEDu7u4KCgpSnz59co3x6KOPysfHR25ubmrUqJGWL19u0yciIkIWi0WfffaZTbu3t7fi4uJy1ZWZmSlvb2+tXbvWZjsWi0VTpkyxthmGoQoVKuijjz7Kc/9uRnx8vM17abFY5Orqan09Y8YM07ZVUH379tVPP/2kX3/99bZvGygpCNkAAADFXJs2bWwC6Pfff6/q1avbtJ09e1a//vqr2rZtq7S0NOtPaGioZs+ebX39xRdf5LmNxYsXq3fv3ipdunSey5955hklJCRoy5YtSktL06ZNmxQWFmZd/ueff6pp06by9/fX77//rjNnzmjSpEkaNmyYFi5caDNWuXLlNHHiRGVlZV133x0dHRUaGmqzrxs2bNA999xj07Zjxw6dOXPGpqZbFRoaavNeStLGjRutrydOnGjatgrKwcFB/fv3LxFnHAD2QsgGAAAo5q4O2XFxcerXr58cHR118OBBSdK3334rLy8vNWjQ4Ka2sXr1arVt2zbf5T/88IP69u0rX19fSVJgYKCGDh1qXT5t2jSFhIRo/vz58vX1lYuLi3r06KF58+ZpwoQJSk1Ntfbt3bu3zp8/r6VLlxaotjZt2mjDhg3W13FxcXr22We1bds2Xbx40dpWv359lStXThkZGZo8ebKqV6+ucuXKqVu3bjp27JjNmN98841q1qwpb29v9e7dW2fPni1QLTkMw9Abb7yh6tWry8fHRw8++KAOHDiQZ98TJ06oYcOGeu6552QYhvbv36+uXbuqQoUKqlKliqZPn279wiEqKkohISF65ZVXVLFiRfn6+ioyMtJmvHbt2unTTz+9oXoBFBwhGwAAoJhr3bq1Tp48qd9//11SdqAMCwtT69atreE7Li5OrVu3loPDjf/z8Pz589q7d69q1aqVb58WLVpo2rRpevvtt7V9+3YZhmGzPDY2Vv369cu1Xu/evXXu3Dlt2rTJ2ubk5KRXXnlFkydPVnp6+nXra9OmjbZs2WIN6t988406dOige++91zpuXFyc2rRpI0maNGmSvv/+e3333XdKTEzU3XffnevU9iVLlmjDhg1KSEhQUlKSxowZc906rl5/7ty5WrVqlY4dO6Y6deqoa9euunz5sk2/ffv2qWXLlho4cKDmzJmjCxcuqF27dmrXrp2OHj2q+Ph4LVu2TO+//751nZ07d8rV1VVHjx7V8uXLNX78eO3fv9+6vHbt2jpx4oQSExNvqGYABUPIBgAAKObKlSun+vXra8OGDTp//rx27typ+++/X61bt7bO8MbFxV1zJvpakpKSJEmenp759pk/f76GDh2qqKgo3X///fL19dXcuXOty0+fPq1KlSrlWq906dIqX768Tp06ZdPep08f+fj46K233rpufQ0aNJCHh4fi4+O1d+9eOTs7KzAw0Lr/hmHo22+/Vdu2bWUYhhYtWqS5c+fK399fpUuX1vTp0/X999/r8OHD1jGfe+45VapUSd7e3nrllVcUExNToNPXcyxZskRPP/206tWrJxcXF82YMUOHDx/WTz/9ZO3zyy+/KCwsTFOnTtUzzzwjSfr8889VtmxZjRkzRqVLl1blypU1evRoxcTEWNcrX768xo0bJycnJ4WFhSk4ONjmRm05v6ec3xsAcxGyAQAASoCcU6a///57NWrUSKVLl7bOZJ89e1Zbt261zuTeqLJly0qSUlJS8u3j7OyscePGaePGjTp79qzmzp2rF154QbGxsZKyg+HVp2RLUkZGhk6fPq0KFSrYtFssFs2aNUuvvvqqzankeXFwcLAG6pxZfEnWth07digpKUmtWrXS6dOnde7cObVq1Ure3t7y9vaWn5+fSpcubROyq1SpYvP3S5cu5foi4FqOHDmi4OBgm/enUqVKOnLkiLXtnXfeUfXq1dWrVy9rW0JCgnbs2GGtzdvbW+PGjdPx48etfXJOyc/h5uZm8x7l/J5yfm8AzEXIBgAAKAHatGmjb775Rhs2bFDr1q0lZT8mymKx6P3331f58uVVp06dmxrb1dVVNWrU0O7duwvU39nZWQMGDFC9evW0Y8cOSdnXCX/44Ye5+i5fvlyurq5q1qxZrmUdOnRQgwYN9Nprr113mznXpeecFi9JTZs21bZt2/TFF1/o3nvvlZeXl8qVKydXV1f9+OOPSk5Otv5cuHBBzZs3t473559/Wv9+6NAhlS5dOtcXAdcSGBiohIQE6+tLly7p2LFjCgwMtLZFRkbKxcVFjz76qDIyMiRJQUFBatSokU1tKSkp2rlzZ4G3vWvXLvn6+srf37/A6wAoOEI2AABACdCqVSudOXNG77//vs0dtFu3bq3Zs2crLCxMFovlpsfv2rWrzc3FrjZ16lRt3LhRFy5cUGZmplavXq1du3apadOmkqTJkydry5YteuaZZ3Ty5EldvHhRq1at0pgxYzR9+nR5eHjkOe6sWbMUGRlpvYFZftq0aaNff/1VsbGx1v13cXFRSEiI3nzzTeup8g4ODho6dKjGjRtnnbk+c+ZMrkeJvfbaazp27JiSk5M1efJk9enT54auZx8wYIAWLFigXbt2KT09XS+++KICAgJ0//33W/u4uLjok08+UXp6uh555BFdunRJXbp00YkTJ7Ro0SJdvHhRmZmZ2rNnT56PL8vP119/rc6dOxe4P4AbQ8gGAAAoxnKCs7e3t+69914lJyerSZMm1uWtW7fW8ePHb/pU8RxPPfWUli1bZp1xvXr7pUqV0rBhw+Tr66ty5cppypQpeuedd6wz1FWrVtWmTZt06NAh1axZU+XKldO0adM0f/58jR49Ot/tNm7cWA899NB1b4BWt25dlS1bVm5ubqpcubK1Pa/9nzlzppo1a6a2bdvKw8NDjRo10rp162zGGzBggNq0aaMqVarIw8ND8+bNK9gb9f8GDRqkUaNGqUuXLvLz89O2bdv06aefqlSpUjb9XFxc9PHHH8swDD388MNycnLSV199pfXr1ys4OFjlypVTv379bE4Xv5asrCxFR0drxIgRN1QvgIKzGFff2rEESklJkZeXl86ePXvNG3YUpoyMDK1Zs0adOnWSk5OTXWoA7InPAEoyjn8UloYNG2rcuHHq37//bdneU089pZCQEA0bNuz/2rv7mCrLP47jnwMIOkWwOQWEloUPa5SuMKbFUmPa5hTmnIZpslm6hpssm7VW4mxLSv/wV5n5GP6BUjrRTZvlAz4VmWknH8qHOU0zwFxDTpAKnOv3B+PkEXwArvME79d2/jgX132f77197yMfr5v71vHjx5WamqqbN2/ec4Wc/vevDRs2aMeOHSoqKgp0KRD9H0xsZsKI+08BAABAqDl+/LhOnTql1NRUv33mypUrJTWulm7cuFHDhg1r1yXosG/q1KktPioNgD2EbAAAgBDQ0CAdPCiVl0vx8VJ6uhQe3vLc2bNna8eOHfrwww81aNAg/xYqKSYmRoMHD9aaNWv8/tkAEGiEbAAAgCC3ZYs0d65029OdlJgo/e9/0sSJzec3rSgHyv0eqQUAHRk3PgMAAAhiW7ZIkyZ5B2xJunKlcXzLlsDUBQBoGSEbAAAgSDU0NK5gt3Sb2qaxvLzGeQCA4EDIBgAACFIHDzZfwb6dMdLly43zAADBgZANAAAQpMrL7c4DAPgeIRsAACBIxcfbnQcA8D1CNgAAQJBKT2+8i/jdHjXtcEhJSY3zAADBgZANAAAQpMLDGx/TJTUP2k3vly27+/OyAQD+R8gGAAAIYhMnSps3S/36eY8nJjaOt/ScbABA4EQEugAAAADc28SJUmZm413Ey8sb/wY7PZ0VbAAIRoRsAACAEBAeLo0cGegqAAD3w+XiAAAAAABYQsgGAAAAAMASQjYAAAAAAJYQsgEAAAAAsISQDQAAAACAJYRsAAAAAAAsIWQDAAAAAGAJIRsAAAAAAEsI2QAAAAAAWELIBgAAAADAEkI2AAAAAACWELIBAAAAALCEkA0AAAAAgCWEbAAAAAAALCFkAwAAAABgCSEbAAAAAABLCNkAAAAAAFhCyAYAAAAAwBJCNgAAAAAAlhCyAQAAAACwhJANAAAAAIAlhGwAAAAAACwhZAMAAAAAYAkhGwAAAAAASyICXUAwMMZIkqqrqwNWQ11dnWpra1VdXa0uXboErA4gUDgH0JnR/+jM6H90ZvR/8GjKgk3ZsD0I2ZJcLpckKSkpKcCVAAAAAAACxeVyKSYmpl37cBgbUT3Eud1u/fnnn4qOjpbD4QhIDdXV1UpKStLly5fVs2fPgNQABBLnADoz+h+dGf2Pzoz+Dx7GGLlcLiUkJCgsrH1/Vc1KtqSwsDAlJiYGugxJUs+ePTnB0KlxDqAzo//RmdH/6Mzo/+DQ3hXsJtz4DAAAAAAASwjZAAAAAABYQsgOElFRUcrPz1dUVFSgSwECgnMAnRn9j86M/kdnRv93TNz4DAAAAAAAS1jJBgAAAADAEkI2AAAAAACWELIBAAAAALCEkO1nxhgtWLBA8fHx6tatmzIyMnTu3LkH3r6goEAOh0N5eXm+KxLwkbb0/+LFizVs2DBFR0erT58+ysrK0pkzZ/xUMWDP8uXL9cgjj6hr165KS0vTjz/+eM/5mzZt0uDBg9W1a1c98cQT+vrrr/1UKWBfa/p/9erVSk9PV69evdSrVy9lZGTc93wBgllrv/+bFBcXy+FwKCsry7cFwjpCtp999NFH+vjjj/X555/r8OHD6t69u8aOHasbN27cd9sjR45o5cqVevLJJ/1QKWBfW/p///79ys3N1Q8//KBdu3aprq5OY8aMUU1NjR8rB9rnyy+/1BtvvKH8/HwdO3ZMQ4YM0dixY3X16tUW53///ffKzs7WzJkz9fPPPysrK0tZWVk6efKknysH2q+1/b9v3z5lZ2ertLRUZWVlSkpK0pgxY3TlyhU/Vw60X2v7v8nFixf15ptvKj093U+VwioDv3G73SYuLs4sWbLEM1ZVVWWioqLMxo0b77mty+UyAwYMMLt27TLPP/+8mTt3ro+rBexqT//f7urVq0aS2b9/vy/KBHzimWeeMbm5uZ73DQ0NJiEhwSxevLjF+ZMnTzbjxo3zGktLSzOzZ8/2aZ2AL7S2/+9UX19voqOjzfr1631VIuAzben/+vp6M2LECLNmzRozY8YMk5mZ6YdKYRMr2X504cIFVVRUKCMjwzMWExOjtLQ0lZWV3XPb3NxcjRs3zmtbIJS0p/9vd/36dUnSQw89ZL1GwBdu3bqlo0ePevV+WFiYMjIy7tr7ZWVlzb7vx44d26pzBQgGben/O9XW1qquro7vfYSctvb/okWL1KdPH82cOdMfZcIHIgJdQGdSUVEhSerbt6/XeN++fT0/a0lxcbGOHTumI0eO+LQ+wJfa2v+3c7vdysvL07PPPquUlBTrNQK+cO3aNTU0NLTY+6dPn25xm4qKinadK0CwaEv/3+mtt95SQkICCw0IOW3p/0OHDmnt2rVyOp1+qBC+wkq2DxUVFalHjx6eV11dXav3cfnyZc2dO1dFRUXq2rWrD6oEfMNG/98pNzdXJ0+eVHFxsYUKAQDBrqCgQMXFxSopKeH3IHR4LpdL06dP1+rVq9W7d+9Al4N2YCXbhyZMmKC0tDTP+5s3b0qSKisrFR8f7xmvrKzU0KFDW9zH0aNHdfXqVT311FOesYaGBh04cECffvqpbt68qfDwcN8cANAONvr/dnPmzNH27dt14MABJSYmWq8X8JXevXsrPDxclZWVXuOVlZWKi4trcZu4uLhWzQeCVVv6v8nSpUtVUFCg3bt3c9NXhKTW9v/58+d18eJFjR8/3jPmdrslSRERETpz5owee+wx3xYNK1jJ9qHo6GglJyd7Xo8//rji4uK0Z88ez5zq6modPnxYw4cPb3EfL7zwgk6cOCGn0+l5paam6uWXX5bT6SRgI2jZ6H+p8bFfc+bMUUlJifbu3av+/fv7o3zAmsjISD399NNeve92u7Vnz5679v7w4cO95kvSrl277nmuAMGoLf0vNT6N4v3339fOnTuVmprqj1IB61rb/4MHD272e/+ECRM0atQoOZ1OJSUl+bN8tEeg77zW2RQUFJjY2Fizbds2c/z4cZOZmWn69+9v/v33X8+c0aNHm08++eSu++Du4ghVben/119/3cTExJh9+/aZ8vJyz6u2tjYQhwC0SXFxsYmKijKFhYXm119/NbNmzTKxsbGmoqLCGGPM9OnTzdtvv+2Z/91335mIiAizdOlS89tvv5n8/HzTpUsXc+LEiUAdAtBmre3/goICExkZaTZv3uz1ve9yuQJ1CECbtbb/78TdxUMTl4v72fz581VTU6NZs2apqqpKzz33nHbu3On1d0bnz5/XtWvXAlgl4Btt6f8VK1ZIkkaOHOm1ry+++EI5OTn+KBtotylTpuivv/7SggULVFFRoaFDh2rnzp2em+FcunRJYWH/XVw2YsQIbdiwQe+++67eeecdDRgwQFu3buWGfwhJre3/FStW6NatW5o0aZLXfvLz87Vw4UJ/lg60W2v7Hx2DwxhjAl0EAAAAAAAdAf9tAgAAAACAJYRsAAAAAAAsIWQDAAAAAGAJIRsAAAAAAEsI2QAAAAAAWELIBgAAAADAEkI2AAAAAACWELIBAAAAALCEkA0AAAAAgCWEbAAAQlROTo4cDoccDociIyOVnJysRYsWqb6+3jPHGKNVq1YpLS1NPXr0UGxsrFJTU7Vs2TLV1tZ67e+PP/5QZGSkUlJSHujzDxw4oPHjxyshIUEOh0Nbt261eXgAAIQkQjYAACHsxRdfVHl5uc6dO6d58+Zp4cKFWrJkiefn06dPV15enjIzM1VaWiqn06n33ntP27Zt07fffuu1r8LCQk2ePFnV1dU6fPjwfT+7pqZGQ4YM0fLly60fFwAAocphjDGBLgIAALReTk6OqqqqvFaQx4wZI5fLpbKyMn311VeaMmWKtm7dqszMTK9tjTGqrq5WTEyM531ycrI+++wzlZaW6u+//9aqVaseuBaHw6GSkhJlZWXZODQAAEIWK9kAAHQg3bp1061btyRJRUVFGjRoULOALTWG4qaALUmlpaWqra1VRkaGpk2bpuLiYtXU1PitbgAAOgpCNgAAHYAxRrt379Y333yj0aNHS5LOnTunQYMGPdD2a9eu1UsvvaTw8HClpKTo0Ucf1aZNm3xZMgAAHVJEoAsAAABtt337dvXo0UN1dXVyu92aOnWqFi5cKKkxeD+IqqoqbdmyRYcOHfKMTZs2TWvXrlVOTo4PqgYAoOMiZAMAEMJGjRqlFStWKDIyUgkJCYqI+O+f9oEDB+r06dP33ceGDRt048YNpaWlecaMMXK73Tp79qwGDhzok9oBAOiIuFwcAIAQ1r17dyUnJ+vhhx/2CtiSNHXqVJ09e1bbtm1rtp0xRtevX5fUeKn4vHnz5HQ6Pa9ffvlF6enpWrdunV+OAwCAjoKQDQBABzV58mRNmTJF2dnZ+uCDD/TTTz/p999/1/bt25WRkeF5pNexY8f06quvKiUlxeuVnZ2t9evXez13+3b//POPJ5RL0oULF+R0OnXp0iU/HiUAAMGFR3gBABCiWnqE153cbrdWrVqldevW6dSpU4qIiNCAAQP0yiuv6LXXXtP8+fO1d+9enTp1qtm2FRUV6tevn0pKSjRhwoRmP9+3b59GjRrVbHzGjBkqLCxsz6EBABCyCNkAAAAAAFjC5eIAAAAAAFhCyAYAAAAAwBJCNgAAAAAAlhCyAQAAAACwhJANAAAAAIAlhGwAAAAAACwhZAMAAAAAYAkhGwAAAAAASwjZAAAAAABYQsgGAAAAAMASQjYAAAAAAJYQsgEAAAAAsOT/P6/UrI8LI6YAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x800 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 05-30 06:27:06 [loggers.py:87] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%\n",
+      "INFO 05-30 06:27:16 [loggers.py:87] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib as mpl\n",
+    "\n",
+    "# 폰트 설정 (NanumGothic이 설치된 경우)\n",
+    "mpl.rcParams['font.family'] = 'DejaVu Sans'\n",
+    "\n",
+    "# 마이너 경고 제거\n",
+    "mpl.rcParams['axes.unicode_minus'] = False\n",
+    "\n",
+    "from sklearn.decomposition import PCA\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "embeddings = model.encode([til] + parsed.keywords_list, normalize_embeddings=True)\n",
+    "\n",
+    "# 4. 유사도 계산\n",
+    "til_embedding = embeddings[0]\n",
+    "keyword_embeddings = embeddings[1:]\n",
+    "similarities = np.dot(keyword_embeddings, til_embedding)  # (10,) 벡터\n",
+    "\n",
+    "# 3. PCA를 사용하여 2차원으로 축소\n",
+    "pca = PCA(n_components=2)\n",
+    "reduced_embeddings = pca.fit_transform(embeddings)\n",
+    "\n",
+    "# 4. 시각화\n",
+    "plt.figure(figsize=(10, 8))\n",
+    "plt.scatter(reduced_embeddings[0, 0], reduced_embeddings[0, 1], color='red', label='TIL')\n",
+    "for i, (x, y) in enumerate(reduced_embeddings[1:]):\n",
+    "    plt.scatter(x, y, color='blue')\n",
+    "    plt.text(x + 0.01, y + 0.01, parsed.keywords_list[i], fontsize=9)\n",
+    "\n",
+    "plt.title(\"2D PCA of TIL and Keyword Embeddings (bge-m3)\")\n",
+    "plt.xlabel(\"PCA 1\")\n",
+    "plt.ylabel(\"PCA 2\")\n",
+    "plt.legend()\n",
+    "plt.grid(True)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Til/vLLM-server/notebook/mvp_v2.ipynb
+++ b/Til/vLLM-server/notebook/mvp_v2.ipynb
@@ -2,106 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: tritonclient[http] in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (2.58.0)\n",
-      "Requirement already satisfied: numpy>=1.19.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (1.26.4)\n",
-      "Requirement already satisfied: python-rapidjson>=0.9.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (1.20)\n",
-      "Requirement already satisfied: urllib3>=2.0.7 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (2.3.0)\n",
-      "Requirement already satisfied: aiohttp<4.0.0,>=3.8.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (3.11.14)\n",
-      "Collecting geventhttpclient>=2.3.3 (from tritonclient[http])\n",
-      "  Downloading geventhttpclient-2.3.3-cp311-cp311-macosx_11_0_arm64.whl.metadata (9.7 kB)\n",
-      "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (2.6.1)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (1.3.2)\n",
-      "Requirement already satisfied: attrs>=17.3.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (25.3.0)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (1.5.0)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (6.2.0)\n",
-      "Requirement already satisfied: propcache>=0.2.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (0.3.0)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (1.18.3)\n",
-      "Collecting gevent (from geventhttpclient>=2.3.3->tritonclient[http])\n",
-      "  Downloading gevent-25.5.1-cp311-cp311-macosx_11_0_universal2.whl.metadata (13 kB)\n",
-      "Requirement already satisfied: certifi in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from geventhttpclient>=2.3.3->tritonclient[http]) (2025.1.31)\n",
-      "Collecting brotli (from geventhttpclient>=2.3.3->tritonclient[http])\n",
-      "  Downloading Brotli-1.1.0-cp311-cp311-macosx_10_9_universal2.whl.metadata (5.5 kB)\n",
-      "Requirement already satisfied: idna>=2.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from yarl<2.0,>=1.17.0->aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (3.10)\n",
-      "Collecting greenlet>=3.2.2 (from gevent->geventhttpclient>=2.3.3->tritonclient[http])\n",
-      "  Downloading greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl.metadata (4.1 kB)\n",
-      "Collecting zope.event (from gevent->geventhttpclient>=2.3.3->tritonclient[http])\n",
-      "  Downloading zope.event-5.0-py3-none-any.whl.metadata (4.4 kB)\n",
-      "Collecting zope.interface (from gevent->geventhttpclient>=2.3.3->tritonclient[http])\n",
-      "  Downloading zope.interface-7.2-cp311-cp311-macosx_11_0_arm64.whl.metadata (44 kB)\n",
-      "Requirement already satisfied: setuptools in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from zope.event->gevent->geventhttpclient>=2.3.3->tritonclient[http]) (75.8.0)\n",
-      "Downloading geventhttpclient-2.3.3-cp311-cp311-macosx_11_0_arm64.whl (51 kB)\n",
-      "Downloading Brotli-1.1.0-cp311-cp311-macosx_10_9_universal2.whl (873 kB)\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m873.1/873.1 kB\u001b[0m \u001b[31m10.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hDownloading gevent-25.5.1-cp311-cp311-macosx_11_0_universal2.whl (2.9 MB)\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m11.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hDownloading greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl (270 kB)\n",
-      "Downloading zope.event-5.0-py3-none-any.whl (6.8 kB)\n",
-      "Downloading zope.interface-7.2-cp311-cp311-macosx_11_0_arm64.whl (209 kB)\n",
-      "Installing collected packages: brotli, zope.interface, zope.event, greenlet, gevent, geventhttpclient\n",
-      "Successfully installed brotli-1.1.0 gevent-25.5.1 geventhttpclient-2.3.3 greenlet-3.2.3 zope.event-5.0 zope.interface-7.2\n"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install 'tritonclient[http]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl http://localhost:8000/v2/models"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "InferenceServerException",
-     "evalue": "[501] HTTP end point doesn't support models with decoupled transaction policy",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mInferenceServerException\u001b[39m                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[41]\u001b[39m\u001b[32m, line 9\u001b[39m\n\u001b[32m      6\u001b[39m input_data = httpclient.InferInput(\u001b[33m\"\u001b[39m\u001b[33mprompt\u001b[39m\u001b[33m\"\u001b[39m, [\u001b[32m1\u001b[39m], \u001b[33m\"\u001b[39m\u001b[33mBYTES\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      7\u001b[39m input_data.set_data_from_numpy(np.array([\u001b[33m\"\u001b[39m\u001b[33m파리는 어떤 나라의 수도야?\u001b[39m\u001b[33m\"\u001b[39m], dtype=\u001b[38;5;28mobject\u001b[39m))\n\u001b[32m----> \u001b[39m\u001b[32m9\u001b[39m results = \u001b[43mclient\u001b[49m\u001b[43m.\u001b[49m\u001b[43minfer\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     10\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmodel_name\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mvllm_model\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# 실제 등록된 모델 이름\u001b[39;49;00m\n\u001b[32m     11\u001b[39m \u001b[43m    \u001b[49m\u001b[43minputs\u001b[49m\u001b[43m=\u001b[49m\u001b[43m[\u001b[49m\u001b[43minput_data\u001b[49m\u001b[43m]\u001b[49m\n\u001b[32m     12\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     14\u001b[39m output = results.as_numpy(\u001b[33m\"\u001b[39m\u001b[33mcompletion\u001b[39m\u001b[33m\"\u001b[39m)[\u001b[32m0\u001b[39m]\n\u001b[32m     15\u001b[39m \u001b[38;5;28mprint\u001b[39m(output.decode())\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/tritonclient/http/_client.py:1482\u001b[39m, in \u001b[36mInferenceServerClient.infer\u001b[39m\u001b[34m(self, model_name, inputs, model_version, outputs, request_id, sequence_id, sequence_start, sequence_end, priority, timeout, headers, query_params, request_compression_algorithm, response_compression_algorithm, parameters)\u001b[39m\n\u001b[32m   1474\u001b[39m     request_uri = \u001b[33m\"\u001b[39m\u001b[33mv2/models/\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[33m/infer\u001b[39m\u001b[33m\"\u001b[39m.format(quote(model_name))\n\u001b[32m   1476\u001b[39m response = \u001b[38;5;28mself\u001b[39m._post(\n\u001b[32m   1477\u001b[39m     request_uri=request_uri,\n\u001b[32m   1478\u001b[39m     request_body=request_body,\n\u001b[32m   1479\u001b[39m     headers=headers,\n\u001b[32m   1480\u001b[39m     query_params=query_params,\n\u001b[32m   1481\u001b[39m )\n\u001b[32m-> \u001b[39m\u001b[32m1482\u001b[39m \u001b[43m_raise_if_error\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1484\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m InferResult(response, \u001b[38;5;28mself\u001b[39m._verbose)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/tritonclient/http/_utils.py:69\u001b[39m, in \u001b[36m_raise_if_error\u001b[39m\u001b[34m(response)\u001b[39m\n\u001b[32m     67\u001b[39m error = _get_error(response)\n\u001b[32m     68\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m error \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m69\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m error\n",
-      "\u001b[31mInferenceServerException\u001b[39m: [501] HTTP end point doesn't support models with decoupled transaction policy"
-     ]
-    }
-   ],
-   "source": [
-    "import tritonclient.http as httpclient\n",
-    "import numpy as np\n",
-    "\n",
-    "client = httpclient.InferenceServerClient(url=\"34.44.52.194:8000\")\n",
-    "\n",
-    "input_data = httpclient.InferInput(\"prompt\", [1], \"BYTES\")\n",
-    "input_data.set_data_from_numpy(np.array([\"파리는 어떤 나라의 수도야?\"], dtype=object))\n",
-    "\n",
-    "results = client.infer(\n",
-    "    model_name=\"vllm_model\",  # 실제 등록된 모델 이름\n",
-    "    inputs=[input_data]\n",
-    ")\n",
-    "\n",
-    "output = results.as_numpy(\"completion\")[0]\n",
-    "print(output.decode())\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -166,7 +67,7 @@
        " 'patch_summary': []}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -386,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -425,7 +326,7 @@
        "5"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -438,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,18 +383,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "client = AsyncOpenAI(\n",
-    "            base_url=\"http://34.44.52.194:8000/v1\", \n",
+    "            base_url=\"http://localhost:9000/v1\", \n",
     "            api_key=\"sk-noauth\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +530,7 @@
     "        \n",
     "\n",
     "        request_payload = {\n",
-    "            \"model\": \"google/gemma-3-4b-it\",\n",
+    "            \"model\": \"gemma-3-4b-it\",\n",
     "            \"messages\": messages,\n",
     "            \"temperature\": 0.1,\n",
     "            \"max_tokens\": 512,\n",
@@ -658,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -681,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +611,7 @@
     "            \"content\": directory_summary_prompt(code_summary=combined_code_summary, category=None, directory=target_directory)\n",
     "        }]\n",
     "        request_payload = {\n",
-    "            \"model\": \"google/gemma-3-4b-it\",\n",
+    "            \"model\": \"gemma-3-4b-it\",\n",
     "            \"messages\": messages,\n",
     "            \"temperature\": 0.1,\n",
     "            \"max_tokens\": 512,\n",
@@ -744,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +662,7 @@
     "        \"content\": til_generate_prompt(date=state.date, combined_directory_summary=combined_directory_summary)\n",
     "    }]\n",
     "    request_payload = {\n",
-    "        \"model\": \"google/gemma-3-4b-it\",\n",
+    "        \"model\": \"gemma-3-4b-it\",\n",
     "        \"messages\": messages,\n",
     "        \"temperature\": 0.1,\n",
     "        \"max_tokens\": 2024,\n",
@@ -800,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -867,48 +768,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n",
       "2\n",
+      "1\n",
       "3\n",
-      "4\n",
-      "5\n"
-     ]
-    },
-    {
-     "ename": "NotFoundError",
-     "evalue": "Error code: 404 - {'error': 'Not Found'}",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNotFoundError\u001b[39m                             Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[23]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m result = \u001b[38;5;28;01mawait\u001b[39;00m graph.ainvoke(input_data)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/__init__.py:1613\u001b[39m, in \u001b[36mPregel.ainvoke\u001b[39m\u001b[34m(self, input, config, stream_mode, output_keys, interrupt_before, interrupt_after, debug, **kwargs)\u001b[39m\n\u001b[32m   1611\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1612\u001b[39m     chunks = []\n\u001b[32m-> \u001b[39m\u001b[32m1613\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mfor\u001b[39;00m chunk \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.astream(\n\u001b[32m   1614\u001b[39m     \u001b[38;5;28minput\u001b[39m,\n\u001b[32m   1615\u001b[39m     config,\n\u001b[32m   1616\u001b[39m     stream_mode=stream_mode,\n\u001b[32m   1617\u001b[39m     output_keys=output_keys,\n\u001b[32m   1618\u001b[39m     interrupt_before=interrupt_before,\n\u001b[32m   1619\u001b[39m     interrupt_after=interrupt_after,\n\u001b[32m   1620\u001b[39m     debug=debug,\n\u001b[32m   1621\u001b[39m     **kwargs,\n\u001b[32m   1622\u001b[39m ):\n\u001b[32m   1623\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m stream_mode == \u001b[33m\"\u001b[39m\u001b[33mvalues\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m   1624\u001b[39m         latest = chunk\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/__init__.py:1502\u001b[39m, in \u001b[36mPregel.astream\u001b[39m\u001b[34m(self, input, config, stream_mode, output_keys, interrupt_before, interrupt_after, debug, subgraphs)\u001b[39m\n\u001b[32m   1491\u001b[39m \u001b[38;5;66;03m# Similarly to Bulk Synchronous Parallel / Pregel model\u001b[39;00m\n\u001b[32m   1492\u001b[39m \u001b[38;5;66;03m# computation proceeds in steps, while there are channel updates\u001b[39;00m\n\u001b[32m   1493\u001b[39m \u001b[38;5;66;03m# channel updates from step N are only visible in step N+1\u001b[39;00m\n\u001b[32m   1494\u001b[39m \u001b[38;5;66;03m# channels are guaranteed to be immutable for the duration of the step,\u001b[39;00m\n\u001b[32m   1495\u001b[39m \u001b[38;5;66;03m# with channel updates applied only at the transition between steps\u001b[39;00m\n\u001b[32m   1496\u001b[39m \u001b[38;5;28;01mwhile\u001b[39;00m loop.tick(\n\u001b[32m   1497\u001b[39m     input_keys=\u001b[38;5;28mself\u001b[39m.input_channels,\n\u001b[32m   1498\u001b[39m     interrupt_before=interrupt_before_,\n\u001b[32m   1499\u001b[39m     interrupt_after=interrupt_after_,\n\u001b[32m   1500\u001b[39m     manager=run_manager,\n\u001b[32m   1501\u001b[39m ):\n\u001b[32m-> \u001b[39m\u001b[32m1502\u001b[39m     \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mfor\u001b[39;00m _ \u001b[38;5;129;01min\u001b[39;00m runner.atick(\n\u001b[32m   1503\u001b[39m         loop.tasks.values(),\n\u001b[32m   1504\u001b[39m         timeout=\u001b[38;5;28mself\u001b[39m.step_timeout,\n\u001b[32m   1505\u001b[39m         retry_policy=\u001b[38;5;28mself\u001b[39m.retry_policy,\n\u001b[32m   1506\u001b[39m         get_waiter=get_waiter,\n\u001b[32m   1507\u001b[39m     ):\n\u001b[32m   1508\u001b[39m         \u001b[38;5;66;03m# emit output\u001b[39;00m\n\u001b[32m   1509\u001b[39m         \u001b[38;5;28;01mfor\u001b[39;00m o \u001b[38;5;129;01min\u001b[39;00m output():\n\u001b[32m   1510\u001b[39m             \u001b[38;5;28;01myield\u001b[39;00m o\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/runner.py:194\u001b[39m, in \u001b[36mPregelRunner.atick\u001b[39m\u001b[34m(self, tasks, reraise, timeout, retry_policy, get_waiter)\u001b[39m\n\u001b[32m    192\u001b[39m     fut.cancel()\n\u001b[32m    193\u001b[39m \u001b[38;5;66;03m# panic on failure or timeout\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m194\u001b[39m \u001b[43m_panic_or_proceed\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    195\u001b[39m \u001b[43m    \u001b[49m\u001b[43mall_futures\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtimeout_exc_cls\u001b[49m\u001b[43m=\u001b[49m\u001b[43masyncio\u001b[49m\u001b[43m.\u001b[49m\u001b[43mTimeoutError\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpanic\u001b[49m\u001b[43m=\u001b[49m\u001b[43mreraise\u001b[49m\n\u001b[32m    196\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/runner.py:273\u001b[39m, in \u001b[36m_panic_or_proceed\u001b[39m\u001b[34m(futs, timeout_exc_cls, panic)\u001b[39m\n\u001b[32m    271\u001b[39m \u001b[38;5;66;03m# raise the exception\u001b[39;00m\n\u001b[32m    272\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m panic:\n\u001b[32m--> \u001b[39m\u001b[32m273\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m exc\n\u001b[32m    274\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    275\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/retry.py:102\u001b[39m, in \u001b[36marun_with_retry\u001b[39m\u001b[34m(task, retry_policy, stream)\u001b[39m\n\u001b[32m    100\u001b[39m         \u001b[38;5;28;01mpass\u001b[39;00m\n\u001b[32m    101\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m102\u001b[39m     \u001b[38;5;28;01mawait\u001b[39;00m task.proc.ainvoke(task.input, config)\n\u001b[32m    103\u001b[39m \u001b[38;5;66;03m# if successful, end\u001b[39;00m\n\u001b[32m    104\u001b[39m \u001b[38;5;28;01mbreak\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/utils/runnable.py:452\u001b[39m, in \u001b[36mRunnableSeq.ainvoke\u001b[39m\u001b[34m(self, input, config, **kwargs)\u001b[39m\n\u001b[32m    450\u001b[39m     coro = step.ainvoke(\u001b[38;5;28minput\u001b[39m, config)\n\u001b[32m    451\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m ASYNCIO_ACCEPTS_CONTEXT:\n\u001b[32m--> \u001b[39m\u001b[32m452\u001b[39m     \u001b[38;5;28minput\u001b[39m = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(coro, context=context)\n\u001b[32m    453\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    454\u001b[39m     \u001b[38;5;28minput\u001b[39m = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(coro)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/utils/runnable.py:235\u001b[39m, in \u001b[36mRunnableCallable.ainvoke\u001b[39m\u001b[34m(self, input, config, **kwargs)\u001b[39m\n\u001b[32m    233\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m ASYNCIO_ACCEPTS_CONTEXT:\n\u001b[32m    234\u001b[39m     coro = cast(Coroutine[\u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;28;01mNone\u001b[39;00m, Any], \u001b[38;5;28mself\u001b[39m.afunc(\u001b[38;5;28minput\u001b[39m, **kwargs))\n\u001b[32m--> \u001b[39m\u001b[32m235\u001b[39m     ret = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(coro, context=context)\n\u001b[32m    236\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    237\u001b[39m     ret = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m.afunc(\u001b[38;5;28minput\u001b[39m, **kwargs)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langsmith/run_helpers.py:522\u001b[39m, in \u001b[36mtraceable.<locals>.decorator.<locals>.async_wrapper\u001b[39m\u001b[34m(langsmith_extra, *args, **kwargs)\u001b[39m\n\u001b[32m    517\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mBaseException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    518\u001b[39m     \u001b[38;5;66;03m# shield from cancellation, given we're catching all exceptions\u001b[39;00m\n\u001b[32m    519\u001b[39m     \u001b[38;5;28;01mawait\u001b[39;00m asyncio.shield(\n\u001b[32m    520\u001b[39m         aitertools.aio_to_thread(_on_run_end, run_container, error=e)\n\u001b[32m    521\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m522\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[32m    523\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m aitertools.aio_to_thread(\n\u001b[32m    524\u001b[39m     _on_run_end, run_container, outputs=function_result\n\u001b[32m    525\u001b[39m )\n\u001b[32m    526\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m function_result\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langsmith/run_helpers.py:508\u001b[39m, in \u001b[36mtraceable.<locals>.decorator.<locals>.async_wrapper\u001b[39m\u001b[34m(langsmith_extra, *args, **kwargs)\u001b[39m\n\u001b[32m    506\u001b[39m fr_coro = func(*args, **kwargs)\n\u001b[32m    507\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m accepts_context:\n\u001b[32m--> \u001b[39m\u001b[32m508\u001b[39m     function_result = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(  \u001b[38;5;66;03m# type: ignore[call-arg]\u001b[39;00m\n\u001b[32m    509\u001b[39m         fr_coro, context=run_container[\u001b[33m\"\u001b[39m\u001b[33mcontext\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m    510\u001b[39m     )\n\u001b[32m    511\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    512\u001b[39m     \u001b[38;5;66;03m# Python < 3.11\u001b[39;00m\n\u001b[32m    513\u001b[39m     \u001b[38;5;28;01mwith\u001b[39;00m tracing_context(\n\u001b[32m    514\u001b[39m         **get_tracing_context(run_container[\u001b[33m\"\u001b[39m\u001b[33mcontext\u001b[39m\u001b[33m\"\u001b[39m])\n\u001b[32m    515\u001b[39m     ):\n",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[17]\u001b[39m\u001b[32m, line 39\u001b[39m, in \u001b[36mmake_code_summary_node.<locals>.summarize_file_node\u001b[39m\u001b[34m(state)\u001b[39m\n\u001b[32m     23\u001b[39m messages = [{\n\u001b[32m     24\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mrole\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33muser\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     25\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mcontent\u001b[39m\u001b[33m\"\u001b[39m: code_summary_prompt(latest_code=latest_code, language=\u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[32m     26\u001b[39m }]\n\u001b[32m     29\u001b[39m request_payload = {\n\u001b[32m     30\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mgoogle/gemma-3-4b-it\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     31\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m: messages,\n\u001b[32m   (...)\u001b[39m\u001b[32m     35\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mstop\u001b[39m\u001b[33m\"\u001b[39m: [\u001b[33m'\u001b[39m\u001b[33m<|im_end|>\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m     36\u001b[39m }\n\u001b[32m---> \u001b[39m\u001b[32m39\u001b[39m response = \u001b[38;5;28;01mawait\u001b[39;00m client.chat.completions.create(**request_payload)\n\u001b[32m     40\u001b[39m summary = response.choices[\u001b[32m0\u001b[39m].message.content\n\u001b[32m     41\u001b[39m original_model = state.directory_dict[target_directory].files[target_filepath]\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py:2000\u001b[39m, in \u001b[36mAsyncCompletions.create\u001b[39m\u001b[34m(self, messages, model, audio, frequency_penalty, function_call, functions, logit_bias, logprobs, max_completion_tokens, max_tokens, metadata, modalities, n, parallel_tool_calls, prediction, presence_penalty, reasoning_effort, response_format, seed, service_tier, stop, store, stream, stream_options, temperature, tool_choice, tools, top_logprobs, top_p, user, web_search_options, extra_headers, extra_query, extra_body, timeout)\u001b[39m\n\u001b[32m   1957\u001b[39m \u001b[38;5;129m@required_args\u001b[39m([\u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m], [\u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mstream\u001b[39m\u001b[33m\"\u001b[39m])\n\u001b[32m   1958\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mcreate\u001b[39m(\n\u001b[32m   1959\u001b[39m     \u001b[38;5;28mself\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1997\u001b[39m     timeout: \u001b[38;5;28mfloat\u001b[39m | httpx.Timeout | \u001b[38;5;28;01mNone\u001b[39;00m | NotGiven = NOT_GIVEN,\n\u001b[32m   1998\u001b[39m ) -> ChatCompletion | AsyncStream[ChatCompletionChunk]:\n\u001b[32m   1999\u001b[39m     validate_response_format(response_format)\n\u001b[32m-> \u001b[39m\u001b[32m2000\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._post(\n\u001b[32m   2001\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m/chat/completions\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   2002\u001b[39m         body=\u001b[38;5;28;01mawait\u001b[39;00m async_maybe_transform(\n\u001b[32m   2003\u001b[39m             {\n\u001b[32m   2004\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m: messages,\n\u001b[32m   2005\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m: model,\n\u001b[32m   2006\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33maudio\u001b[39m\u001b[33m\"\u001b[39m: audio,\n\u001b[32m   2007\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mfrequency_penalty\u001b[39m\u001b[33m\"\u001b[39m: frequency_penalty,\n\u001b[32m   2008\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mfunction_call\u001b[39m\u001b[33m\"\u001b[39m: function_call,\n\u001b[32m   2009\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mfunctions\u001b[39m\u001b[33m\"\u001b[39m: functions,\n\u001b[32m   2010\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mlogit_bias\u001b[39m\u001b[33m\"\u001b[39m: logit_bias,\n\u001b[32m   2011\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mlogprobs\u001b[39m\u001b[33m\"\u001b[39m: logprobs,\n\u001b[32m   2012\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmax_completion_tokens\u001b[39m\u001b[33m\"\u001b[39m: max_completion_tokens,\n\u001b[32m   2013\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmax_tokens\u001b[39m\u001b[33m\"\u001b[39m: max_tokens,\n\u001b[32m   2014\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmetadata\u001b[39m\u001b[33m\"\u001b[39m: metadata,\n\u001b[32m   2015\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmodalities\u001b[39m\u001b[33m\"\u001b[39m: modalities,\n\u001b[32m   2016\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mn\u001b[39m\u001b[33m\"\u001b[39m: n,\n\u001b[32m   2017\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mparallel_tool_calls\u001b[39m\u001b[33m\"\u001b[39m: parallel_tool_calls,\n\u001b[32m   2018\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mprediction\u001b[39m\u001b[33m\"\u001b[39m: prediction,\n\u001b[32m   2019\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mpresence_penalty\u001b[39m\u001b[33m\"\u001b[39m: presence_penalty,\n\u001b[32m   2020\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mreasoning_effort\u001b[39m\u001b[33m\"\u001b[39m: reasoning_effort,\n\u001b[32m   2021\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mresponse_format\u001b[39m\u001b[33m\"\u001b[39m: response_format,\n\u001b[32m   2022\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mseed\u001b[39m\u001b[33m\"\u001b[39m: seed,\n\u001b[32m   2023\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mservice_tier\u001b[39m\u001b[33m\"\u001b[39m: service_tier,\n\u001b[32m   2024\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstop\u001b[39m\u001b[33m\"\u001b[39m: stop,\n\u001b[32m   2025\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstore\u001b[39m\u001b[33m\"\u001b[39m: store,\n\u001b[32m   2026\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstream\u001b[39m\u001b[33m\"\u001b[39m: stream,\n\u001b[32m   2027\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstream_options\u001b[39m\u001b[33m\"\u001b[39m: stream_options,\n\u001b[32m   2028\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtemperature\u001b[39m\u001b[33m\"\u001b[39m: temperature,\n\u001b[32m   2029\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtool_choice\u001b[39m\u001b[33m\"\u001b[39m: tool_choice,\n\u001b[32m   2030\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtools\u001b[39m\u001b[33m\"\u001b[39m: tools,\n\u001b[32m   2031\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtop_logprobs\u001b[39m\u001b[33m\"\u001b[39m: top_logprobs,\n\u001b[32m   2032\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtop_p\u001b[39m\u001b[33m\"\u001b[39m: top_p,\n\u001b[32m   2033\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33muser\u001b[39m\u001b[33m\"\u001b[39m: user,\n\u001b[32m   2034\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mweb_search_options\u001b[39m\u001b[33m\"\u001b[39m: web_search_options,\n\u001b[32m   2035\u001b[39m             },\n\u001b[32m   2036\u001b[39m             completion_create_params.CompletionCreateParams,\n\u001b[32m   2037\u001b[39m         ),\n\u001b[32m   2038\u001b[39m         options=make_request_options(\n\u001b[32m   2039\u001b[39m             extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout\n\u001b[32m   2040\u001b[39m         ),\n\u001b[32m   2041\u001b[39m         cast_to=ChatCompletion,\n\u001b[32m   2042\u001b[39m         stream=stream \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[32m   2043\u001b[39m         stream_cls=AsyncStream[ChatCompletionChunk],\n\u001b[32m   2044\u001b[39m     )\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/_base_client.py:1767\u001b[39m, in \u001b[36mAsyncAPIClient.post\u001b[39m\u001b[34m(self, path, cast_to, body, files, options, stream, stream_cls)\u001b[39m\n\u001b[32m   1753\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mpost\u001b[39m(\n\u001b[32m   1754\u001b[39m     \u001b[38;5;28mself\u001b[39m,\n\u001b[32m   1755\u001b[39m     path: \u001b[38;5;28mstr\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1762\u001b[39m     stream_cls: \u001b[38;5;28mtype\u001b[39m[_AsyncStreamT] | \u001b[38;5;28;01mNone\u001b[39;00m = \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m   1763\u001b[39m ) -> ResponseT | _AsyncStreamT:\n\u001b[32m   1764\u001b[39m     opts = FinalRequestOptions.construct(\n\u001b[32m   1765\u001b[39m         method=\u001b[33m\"\u001b[39m\u001b[33mpost\u001b[39m\u001b[33m\"\u001b[39m, url=path, json_data=body, files=\u001b[38;5;28;01mawait\u001b[39;00m async_to_httpx_files(files), **options\n\u001b[32m   1766\u001b[39m     )\n\u001b[32m-> \u001b[39m\u001b[32m1767\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m.request(cast_to, opts, stream=stream, stream_cls=stream_cls)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/_base_client.py:1461\u001b[39m, in \u001b[36mAsyncAPIClient.request\u001b[39m\u001b[34m(self, cast_to, options, stream, stream_cls, remaining_retries)\u001b[39m\n\u001b[32m   1458\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1459\u001b[39m     retries_taken = \u001b[32m0\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m1461\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._request(\n\u001b[32m   1462\u001b[39m     cast_to=cast_to,\n\u001b[32m   1463\u001b[39m     options=options,\n\u001b[32m   1464\u001b[39m     stream=stream,\n\u001b[32m   1465\u001b[39m     stream_cls=stream_cls,\n\u001b[32m   1466\u001b[39m     retries_taken=retries_taken,\n\u001b[32m   1467\u001b[39m )\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/_base_client.py:1562\u001b[39m, in \u001b[36mAsyncAPIClient._request\u001b[39m\u001b[34m(self, cast_to, options, stream, stream_cls, retries_taken)\u001b[39m\n\u001b[32m   1559\u001b[39m         \u001b[38;5;28;01mawait\u001b[39;00m err.response.aread()\n\u001b[32m   1561\u001b[39m     log.debug(\u001b[33m\"\u001b[39m\u001b[33mRe-raising status error\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m-> \u001b[39m\u001b[32m1562\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;28mself\u001b[39m._make_status_error_from_response(err.response) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m   1564\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._process_response(\n\u001b[32m   1565\u001b[39m     cast_to=cast_to,\n\u001b[32m   1566\u001b[39m     options=options,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1570\u001b[39m     retries_taken=retries_taken,\n\u001b[32m   1571\u001b[39m )\n",
-      "\u001b[31mNotFoundError\u001b[39m: Error code: 404 - {'error': 'Not Found'}"
+      "5\n",
+      "4\n"
      ]
     }
    ],
    "source": [
     "result = await graph.ainvoke(input_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# 📅 2025-03-11 TIL\n",
+      "\n",
+      "### 📖 1. 오늘 배운 내용\n",
+      "\n",
+      "FastAPI 애플리케이션의 API 엔드포인트 기능 개선 및 데이터베이스 스키마 변경을 위한 Alembic 마이그레이션 구현에 대한 내용을 학습했습니다.  루트 경로, 건강 상태 확인, 게시글 생성 API 엔드포인트가 추가되었고, CORS 미들웨어를 통해 프론트엔드와의 통신을 안전하게 처리하도록 설정되었습니다. 또한, `posts` 테이블에 `author` 컬럼을 추가하고 삭제하는 Alembic 마이그레이션 스크립트가 적용되었습니다.\n",
+      "\n",
+      "### 📚 2. 개념 정리\n",
+      "\n",
+      "*   **FastAPI:**  빠른 웹 프레임워크로, 비동기 프로그래밍을 지원하며, 타입 힌트를 활용하여 코드의 안정성을 높입니다.\n",
+      "*   **Uvicorn:**  FastAPI 애플리케이션을 실행하기 위한 ASGI 서버입니다.\n",
+      "*   **Alembic:**  Python 데이터베이스 마이그레이션 도구로, 데이터베이스 스키마 변경을 추적하고 관리하는 데 사용됩니다.\n",
+      "*   **SQLAlchemy:**  Python에서 데이터베이스 작업을 수행하기 위한 ORM(Object-Relational Mapper)입니다.\n",
+      "*   **CORS (Cross-Origin Resource Sharing):**  다른 도메인에서 웹 페이지가 리소스를 요청할 때 보안 문제를 해결하기 위한 메커니즘입니다.\n",
+      "*   **POST 요청:**  서버에 데이터를 전송하는 HTTP 요청 메서드입니다.\n",
+      "\n",
+      "### 🤔 3. 해당 개념이 필요한 이유\n",
+      "\n",
+      "FastAPI는 현대적인 웹 애플리케이션 개발에 필요한 다양한 기능을 제공하며, Uvicorn은 높은 성능으로 애플리케이션을 실행할 수 있도록 지원합니다. Alembic는 데이터베이스 변경 사항을 체계적으로 관리하여 개발 및 유지 보수를 용이하게 합니다. CORS는 프론트엔드와 백엔드가 서로 다른 도메인에서 동작할 때 보안 문제를 방지하기 위해 필수적입니다.  API 엔드포인트의 접근성을 높이고, 프론트엔드와의 통신을 안전하게 처리하며, 데이터베이스 스키마를 효율적으로 관리하기 위해 이러한 기술들을 활용해야 합니다.\n",
+      "\n",
+      "### 💡 4. 개념을 활용하는 방법\n",
+      "\n",
+      "*   **FastAPI:**  API 엔드포인트를 정의하고, 요청 및 응답을 처리하는 데 사용합니다.  타입 힌트를 사용하여 코드의 가독성과 안정성을 높일 수 있습니다.\n",
+      "*   **Uvicorn:**  FastAPI 애플리케이션을 실행하고, HTTP 요청을 처리하는 데 사용합니다.\n",
+      "*   **Alembic:**  데이터베이스 스키마 변경을 위한 마이그레이션 파일을 생성하고, 실행하여 데이터베이스를 업데이트하는 데 사용합니다.  마이그레이션 파일은 변경 사항을 추적하고, 롤백을 지원합니다.\n",
+      "*   **SQLAlchemy:**  데이터베이스 연결을 설정하고, SQL 쿼리를 작성하여 데이터베이스와 상호 작용하는 데 사용합니다.\n",
+      "*   **CORS:**  프론트엔드와 백엔드 간의 CORS 설정을 통해, 허용된 도메인에서만 API 요청을 받을 수 있도록 설정합니다.  `pip install cors`를 통해 설치하고, FastAPI 애플리케이션에 CORS 미들웨어를 적용합니다.\n",
+      "\n",
+      "### 🛠️ 5. 문제 해결 과정\n",
+      "\n",
+      "CORS 설정에서 프론트엔드 URL을 정확하게 지정하지 않아 요청이 차단되는 문제가 있었습니다.  Vite 프론트엔드 URL을 CORS 설정에 추가하고, 모든 HTTP 메서드와 헤더를 허용하도록 설정하여 문제를 해결했습니다. Alembic 마이그레이션 스크립트 실행 시 데이터베이스 오류가 발생했는데, 데이터베이스 연결 정보가 올바른지 확인하고, 마이그레이션 스크립트가 데이터베이스 스키마와 일치하는지 확인하여 문제를 해결했습니다.\n",
+      "\n",
+      "### ✍️ 6. 하루 회고\n",
+      "\n",
+      "오늘 학습한 내용을 바탕으로 API 엔드포인트를 더욱 안정적이고 효율적으로 개발할 수 있을 것 같습니다.  특히, CORS 설정과 Alembic 마이그레이션 도구의 활용법을 숙지하여 실제 프로젝트에 적용해 볼 계획입니다.  또한, 코드 스타일 및 설정 파일 최적화를 통해 개발 생산성을 높이는 데에도 노력할 것입니다.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result[\"til_content\"])"
    ]
   },
   {
@@ -1057,7 +984,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Deeplearning",
+   "display_name": "test",
    "language": "python",
    "name": "python3"
   },
@@ -1071,7 +998,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/Til/vLLM-server/notebook/mvp_v2.ipynb
+++ b/Til/vLLM-server/notebook/mvp_v2.ipynb
@@ -1,0 +1,1079 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: tritonclient[http] in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (2.58.0)\n",
+      "Requirement already satisfied: numpy>=1.19.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (1.26.4)\n",
+      "Requirement already satisfied: python-rapidjson>=0.9.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (1.20)\n",
+      "Requirement already satisfied: urllib3>=2.0.7 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (2.3.0)\n",
+      "Requirement already satisfied: aiohttp<4.0.0,>=3.8.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from tritonclient[http]) (3.11.14)\n",
+      "Collecting geventhttpclient>=2.3.3 (from tritonclient[http])\n",
+      "  Downloading geventhttpclient-2.3.3-cp311-cp311-macosx_11_0_arm64.whl.metadata (9.7 kB)\n",
+      "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (2.6.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (1.3.2)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (25.3.0)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (1.5.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (6.2.0)\n",
+      "Requirement already satisfied: propcache>=0.2.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (0.3.0)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (1.18.3)\n",
+      "Collecting gevent (from geventhttpclient>=2.3.3->tritonclient[http])\n",
+      "  Downloading gevent-25.5.1-cp311-cp311-macosx_11_0_universal2.whl.metadata (13 kB)\n",
+      "Requirement already satisfied: certifi in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from geventhttpclient>=2.3.3->tritonclient[http]) (2025.1.31)\n",
+      "Collecting brotli (from geventhttpclient>=2.3.3->tritonclient[http])\n",
+      "  Downloading Brotli-1.1.0-cp311-cp311-macosx_10_9_universal2.whl.metadata (5.5 kB)\n",
+      "Requirement already satisfied: idna>=2.0 in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from yarl<2.0,>=1.17.0->aiohttp<4.0.0,>=3.8.1->tritonclient[http]) (3.10)\n",
+      "Collecting greenlet>=3.2.2 (from gevent->geventhttpclient>=2.3.3->tritonclient[http])\n",
+      "  Downloading greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl.metadata (4.1 kB)\n",
+      "Collecting zope.event (from gevent->geventhttpclient>=2.3.3->tritonclient[http])\n",
+      "  Downloading zope.event-5.0-py3-none-any.whl.metadata (4.4 kB)\n",
+      "Collecting zope.interface (from gevent->geventhttpclient>=2.3.3->tritonclient[http])\n",
+      "  Downloading zope.interface-7.2-cp311-cp311-macosx_11_0_arm64.whl.metadata (44 kB)\n",
+      "Requirement already satisfied: setuptools in /opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages (from zope.event->gevent->geventhttpclient>=2.3.3->tritonclient[http]) (75.8.0)\n",
+      "Downloading geventhttpclient-2.3.3-cp311-cp311-macosx_11_0_arm64.whl (51 kB)\n",
+      "Downloading Brotli-1.1.0-cp311-cp311-macosx_10_9_universal2.whl (873 kB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m873.1/873.1 kB\u001b[0m \u001b[31m10.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hDownloading gevent-25.5.1-cp311-cp311-macosx_11_0_universal2.whl (2.9 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m11.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hDownloading greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl (270 kB)\n",
+      "Downloading zope.event-5.0-py3-none-any.whl (6.8 kB)\n",
+      "Downloading zope.interface-7.2-cp311-cp311-macosx_11_0_arm64.whl (209 kB)\n",
+      "Installing collected packages: brotli, zope.interface, zope.event, greenlet, gevent, geventhttpclient\n",
+      "Successfully installed brotli-1.1.0 gevent-25.5.1 geventhttpclient-2.3.3 greenlet-3.2.3 zope.event-5.0 zope.interface-7.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install 'tritonclient[http]'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl http://localhost:8000/v2/models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "InferenceServerException",
+     "evalue": "[501] HTTP end point doesn't support models with decoupled transaction policy",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mInferenceServerException\u001b[39m                  Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[41]\u001b[39m\u001b[32m, line 9\u001b[39m\n\u001b[32m      6\u001b[39m input_data = httpclient.InferInput(\u001b[33m\"\u001b[39m\u001b[33mprompt\u001b[39m\u001b[33m\"\u001b[39m, [\u001b[32m1\u001b[39m], \u001b[33m\"\u001b[39m\u001b[33mBYTES\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      7\u001b[39m input_data.set_data_from_numpy(np.array([\u001b[33m\"\u001b[39m\u001b[33m파리는 어떤 나라의 수도야?\u001b[39m\u001b[33m\"\u001b[39m], dtype=\u001b[38;5;28mobject\u001b[39m))\n\u001b[32m----> \u001b[39m\u001b[32m9\u001b[39m results = \u001b[43mclient\u001b[49m\u001b[43m.\u001b[49m\u001b[43minfer\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     10\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmodel_name\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mvllm_model\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# 실제 등록된 모델 이름\u001b[39;49;00m\n\u001b[32m     11\u001b[39m \u001b[43m    \u001b[49m\u001b[43minputs\u001b[49m\u001b[43m=\u001b[49m\u001b[43m[\u001b[49m\u001b[43minput_data\u001b[49m\u001b[43m]\u001b[49m\n\u001b[32m     12\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     14\u001b[39m output = results.as_numpy(\u001b[33m\"\u001b[39m\u001b[33mcompletion\u001b[39m\u001b[33m\"\u001b[39m)[\u001b[32m0\u001b[39m]\n\u001b[32m     15\u001b[39m \u001b[38;5;28mprint\u001b[39m(output.decode())\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/tritonclient/http/_client.py:1482\u001b[39m, in \u001b[36mInferenceServerClient.infer\u001b[39m\u001b[34m(self, model_name, inputs, model_version, outputs, request_id, sequence_id, sequence_start, sequence_end, priority, timeout, headers, query_params, request_compression_algorithm, response_compression_algorithm, parameters)\u001b[39m\n\u001b[32m   1474\u001b[39m     request_uri = \u001b[33m\"\u001b[39m\u001b[33mv2/models/\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[33m/infer\u001b[39m\u001b[33m\"\u001b[39m.format(quote(model_name))\n\u001b[32m   1476\u001b[39m response = \u001b[38;5;28mself\u001b[39m._post(\n\u001b[32m   1477\u001b[39m     request_uri=request_uri,\n\u001b[32m   1478\u001b[39m     request_body=request_body,\n\u001b[32m   1479\u001b[39m     headers=headers,\n\u001b[32m   1480\u001b[39m     query_params=query_params,\n\u001b[32m   1481\u001b[39m )\n\u001b[32m-> \u001b[39m\u001b[32m1482\u001b[39m \u001b[43m_raise_if_error\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1484\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m InferResult(response, \u001b[38;5;28mself\u001b[39m._verbose)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/tritonclient/http/_utils.py:69\u001b[39m, in \u001b[36m_raise_if_error\u001b[39m\u001b[34m(response)\u001b[39m\n\u001b[32m     67\u001b[39m error = _get_error(response)\n\u001b[32m     68\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m error \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m69\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m error\n",
+      "\u001b[31mInferenceServerException\u001b[39m: [501] HTTP end point doesn't support models with decoupled transaction policy"
+     ]
+    }
+   ],
+   "source": [
+    "import tritonclient.http as httpclient\n",
+    "import numpy as np\n",
+    "\n",
+    "client = httpclient.InferenceServerClient(url=\"34.44.52.194:8000\")\n",
+    "\n",
+    "input_data = httpclient.InferInput(\"prompt\", [1], \"BYTES\")\n",
+    "input_data.set_data_from_numpy(np.array([\"파리는 어떤 나라의 수도야?\"], dtype=object))\n",
+    "\n",
+    "results = client.infer(\n",
+    "    model_name=\"vllm_model\",  # 실제 등록된 모델 이름\n",
+    "    inputs=[input_data]\n",
+    ")\n",
+    "\n",
+    "output = results.as_numpy(\"completion\")[0]\n",
+    "print(output.decode())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel\n",
+    "from typing import List, Dict, Optional, Any, Annotated\n",
+    "from pprint import pprint\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "# langgraph 정의\n",
+    "from langgraph.graph import StateGraph\n",
+    "from langchain_teddynote.graphs import visualize_graph\n",
+    "from langsmith import traceable\n",
+    "from unidiff import PatchSet\n",
+    "\n",
+    "from openai import AsyncOpenAI\n",
+    "\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"dataset_mvp_runs.jsonl\", \"r\" ,encoding= 'utf-8') as f:\n",
+    "    data_mvp = [json.loads(line) for line in f]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'date': '2025-03-11',\n",
+       " 'repo': '943724054',\n",
+       " 'files': [{'patches': [{'patch': '@@ -19,4 +19,4 @@ RUN echo \"DATABASE_URL=${DATABASE_URL}\" > .env\\n EXPOSE 8000\\n \\n # 7. FastAPI 실행 명령\\n-CMD [\"uvicorn\", \"main:app\", \"--host\", \"0.0.0.0\", \"--port\", \"8000\"]\\n\\\\ No newline at end of file\\n+CMD alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000\\n\\\\ No newline at end of file',\n",
+       "     'commit_message': 'feat: 데이터 베이스 업데이트 추가'}],\n",
+       "   'filepath': 'Dockerfile',\n",
+       "   'latest_code': '# 1. Python 3.10 이미지 사용\\nFROM python:3.10\\n\\n# 2. 작업 디렉토리 설정\\n# WORKDIR /app\\n\\n# 3. 종속성 파일 복사 후 패키지 설치\\nCOPY requirements.txt .\\nRUN pip install --no-cache-dir -r requirements.txt\\n\\n# 4. 애플리케이션 코드 복사\\nCOPY . .\\n\\n# 5. GitHub Actions에서 환경 변수를 받아 `.env` 파일로 저장\\nARG DATABASE_URL\\nRUN echo \"DATABASE_URL=${DATABASE_URL}\" > .env\\n\\n# 6. 컨테이너에서 실행할 포트 설정\\nEXPOSE 8000\\n\\n# 7. FastAPI 실행 명령\\nCMD alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000'},\n",
+       "  {'patches': [{'patch': '@@ -48,6 +48,5 @@ htmlcov/\\n .pyrightcache/\\n \\n # Alembic 관련\\n-alembic.ini\\n alembic/versions/__pycache__/\\n ',\n",
+       "     'commit_message': 'feat: database 업데이트'}],\n",
+       "   'filepath': '.gitignore',\n",
+       "   'latest_code': '# 📂 Python 가상환경 (venv, .venv 폴더 제외)\\nvenv/\\n.venv/\\n\\n# 📂 Python 컴파일된 파일 및 캐시 폴더\\n__pycache__/\\n*.pyc\\n*.pyo\\n*.pyd\\n\\n# 📂 환경 변수 파일 (보안 중요)\\n.env\\n*.env\\n\\n# 📂 프로젝트 실행 시 생성되는 파일\\n*.log\\n*.sqlite3\\ninstance/\\n\\n# 📂 IDE 및 편집기 관련 파일\\n.vscode/\\n.idea/\\n*.iml\\n\\n# 📂 Jupyter Notebook 체크포인트 (필요 없으면 제거 가능)\\n.ipynb_checkpoints/\\n\\n# 📂 OS별 불필요한 파일\\n.DS_Store\\nThumbs.db\\n\\n# 📂 FastAPI + Uvicorn 실행 관련 파일\\n*.pid\\n*.sock\\n\\n# 📂 Docker 관련 파일 (도커 사용 시 필요)\\ndocker-compose.override.yml\\n\\n# 📂 Pytest, Coverage 관련\\n.coverage\\npytest_cache/\\nhtmlcov/\\n\\n# 📂 MyPy, pylint, pyright 등 linter 관련\\n.mypy_cache/\\n.pylint.d/\\n.pytest_cache/\\n.pyrightcache/\\n\\n# Alembic 관련\\nalembic/versions/__pycache__/\\n\\n'},\n",
+       "  {'patches': [{'patch': '@@ -0,0 +1,118 @@\\n+# A generic, single database configuration.\\n+\\n+[alembic]\\n+# path to migration scripts\\n+# Use forward slashes (/) also on windows to provide an os agnostic path\\n+script_location = alembic\\n+\\n+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s\\n+# Uncomment the line below if you want the files to be prepended with date and time\\n+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file\\n+# for all available tokens\\n+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s\\n+\\n+# sys.path path, will be prepended to sys.path if present.\\n+# defaults to the current working directory.\\n+prepend_sys_path = .\\n+\\n+# timezone to use when rendering the date within the migration file\\n+# as well as the filename.\\n+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.\\n+# Any required deps can installed by adding `alembic[tz]` to the pip requirements\\n+# string value is passed to ZoneInfo()\\n+# leave blank for localtime\\n+# timezone =\\n+\\n+# max length of characters to apply to the \"slug\" field\\n+# truncate_slug_length = 40\\n+\\n+# set to \\'true\\' to run the environment during\\n+# the \\'revision\\' command, regardless of autogenerate\\n+# revision_environment = false\\n+\\n+# set to \\'true\\' to allow .pyc and .pyo files without\\n+# a source .py file to be detected as revisions in the\\n+# versions/ directory\\n+# sourceless = false\\n+\\n+# version location specification; This defaults\\n+# to alembic/versions.  When using multiple version\\n+# directories, initial revisions must be specified with --version-path.\\n+# The path separator used here should be the separator specified by \"version_path_separator\" below.\\n+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions\\n+\\n+# version path separator; As mentioned above, this is the character used to split\\n+# version_locations. The default within new alembic.ini files is \"os\", which uses os.pathsep.\\n+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.\\n+# Valid values for version_path_separator are:\\n+#\\n+# version_path_separator = :\\n+# version_path_separator = ;\\n+# version_path_separator = space\\n+# version_path_separator = newline\\n+#\\n+# Use os.pathsep. Default configuration used for new projects.\\n+version_path_separator = os\\n+\\n+# set to \\'true\\' to search source files recursively\\n+# in each \"version_locations\" directory\\n+# new in Alembic version 1.10\\n+# recursive_version_locations = false\\n+\\n+# the output encoding used when revision files\\n+# are written from script.py.mako\\n+# output_encoding = utf-8\\n+\\n+sqlalchemy.url = %(DATABASE_URL)s\\n+\\n+[post_write_hooks]\\n+# post_write_hooks defines scripts or Python functions that are run\\n+# on newly generated revision scripts.  See the documentation for further\\n+# detail and examples\\n+\\n+# format using \"black\" - use the console_scripts runner, against the \"black\" entrypoint\\n+# hooks = black\\n+# black.type = console_scripts\\n+# black.entrypoint = black\\n+# black.options = -l 79 REVISION_SCRIPT_FILENAME\\n+\\n+# lint with attempts to fix using \"ruff\" - use the exec runner, execute a binary\\n+# hooks = ruff\\n+# ruff.type = exec\\n+# ruff.executable = %(here)s/.venv/bin/ruff\\n+# ruff.options = check --fix REVISION_SCRIPT_FILENAME\\n+\\n+# Logging configuration\\n+[loggers]\\n+keys = root,sqlalchemy,alembic\\n+\\n+[handlers]\\n+keys = console\\n+\\n+[formatters]\\n+keys = generic\\n+\\n+[logger_root]\\n+level = WARNING\\n+handlers = console\\n+qualname =\\n+\\n+[logger_sqlalchemy]\\n+level = WARNING\\n+handlers =\\n+qualname = sqlalchemy.engine\\n+\\n+[logger_alembic]\\n+level = INFO\\n+handlers =\\n+qualname = alembic\\n+\\n+[handler_console]\\n+class = StreamHandler\\n+args = (sys.stderr,)\\n+level = NOTSET\\n+formatter = generic\\n+\\n+[formatter_generic]\\n+format = %(levelname)-5.5s [%(name)s] %(message)s\\n+datefmt = %H:%M:%S',\n",
+       "     'commit_message': 'feat: database 업데이트'}],\n",
+       "   'filepath': 'alembic.ini',\n",
+       "   'latest_code': '# A generic, single database configuration.\\n\\n[alembic]\\n# path to migration scripts\\n# Use forward slashes (/) also on windows to provide an os agnostic path\\nscript_location = alembic\\n\\n# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s\\n# Uncomment the line below if you want the files to be prepended with date and time\\n# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file\\n# for all available tokens\\n# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s\\n\\n# sys.path path, will be prepended to sys.path if present.\\n# defaults to the current working directory.\\nprepend_sys_path = .\\n\\n# timezone to use when rendering the date within the migration file\\n# as well as the filename.\\n# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.\\n# Any required deps can installed by adding `alembic[tz]` to the pip requirements\\n# string value is passed to ZoneInfo()\\n# leave blank for localtime\\n# timezone =\\n\\n# max length of characters to apply to the \"slug\" field\\n# truncate_slug_length = 40\\n\\n# set to \\'true\\' to run the environment during\\n# the \\'revision\\' command, regardless of autogenerate\\n# revision_environment = false\\n\\n# set to \\'true\\' to allow .pyc and .pyo files without\\n# a source .py file to be detected as revisions in the\\n# versions/ directory\\n# sourceless = false\\n\\n# version location specification; This defaults\\n# to alembic/versions.  When using multiple version\\n# directories, initial revisions must be specified with --version-path.\\n# The path separator used here should be the separator specified by \"version_path_separator\" below.\\n# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions\\n\\n# version path separator; As mentioned above, this is the character used to split\\n# version_locations. The default within new alembic.ini files is \"os\", which uses os.pathsep.\\n# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.\\n# Valid values for version_path_separator are:\\n#\\n# version_path_separator = :\\n# version_path_separator = ;\\n# version_path_separator = space\\n# version_path_separator = newline\\n#\\n# Use os.pathsep. Default configuration used for new projects.\\nversion_path_separator = os\\n\\n# set to \\'true\\' to search source files recursively\\n# in each \"version_locations\" directory\\n# new in Alembic version 1.10\\n# recursive_version_locations = false\\n\\n# the output encoding used when revision files\\n# are written from script.py.mako\\n# output_encoding = utf-8\\n\\nsqlalchemy.url = %(DATABASE_URL)s\\n\\n[post_write_hooks]\\n# post_write_hooks defines scripts or Python functions that are run\\n# on newly generated revision scripts.  See the documentation for further\\n# detail and examples\\n\\n# format using \"black\" - use the console_scripts runner, against the \"black\" entrypoint\\n# hooks = black\\n# black.type = console_scripts\\n# black.entrypoint = black\\n# black.options = -l 79 REVISION_SCRIPT_FILENAME\\n\\n# lint with attempts to fix using \"ruff\" - use the exec runner, execute a binary\\n# hooks = ruff\\n# ruff.type = exec\\n# ruff.executable = %(here)s/.venv/bin/ruff\\n# ruff.options = check --fix REVISION_SCRIPT_FILENAME\\n\\n# Logging configuration\\n[loggers]\\nkeys = root,sqlalchemy,alembic\\n\\n[handlers]\\nkeys = console\\n\\n[formatters]\\nkeys = generic\\n\\n[logger_root]\\nlevel = WARNING\\nhandlers = console\\nqualname =\\n\\n[logger_sqlalchemy]\\nlevel = WARNING\\nhandlers =\\nqualname = sqlalchemy.engine\\n\\n[logger_alembic]\\nlevel = INFO\\nhandlers =\\nqualname = alembic\\n\\n[handler_console]\\nclass = StreamHandler\\nargs = (sys.stderr,)\\nlevel = NOTSET\\nformatter = generic\\n\\n[formatter_generic]\\nformat = %(levelname)-5.5s [%(name)s] %(message)s\\ndatefmt = %H:%M:%S\\n'},\n",
+       "  {'patches': [{'patch': '@@ -0,0 +1,32 @@\\n+\"\"\"Updated schema\\n+\\n+Revision ID: c49e19c13dfb\\n+Revises: 8532de57310b\\n+Create Date: 2025-03-11 11:22:03.149091\\n+\\n+\"\"\"\\n+from typing import Sequence, Union\\n+\\n+from alembic import op\\n+import sqlalchemy as sa\\n+\\n+\\n+# revision identifiers, used by Alembic.\\n+revision: str = \\'c49e19c13dfb\\'\\n+down_revision: Union[str, None] = \\'8532de57310b\\'\\n+branch_labels: Union[str, Sequence[str], None] = None\\n+depends_on: Union[str, Sequence[str], None] = None\\n+\\n+\\n+def upgrade() -> None:\\n+    \"\"\"Upgrade schema.\"\"\"\\n+    # ### commands auto generated by Alembic - please adjust! ###\\n+    op.add_column(\\'posts\\', sa.Column(\\'author\\', sa.String(length=100), nullable=False))\\n+    # ### end Alembic commands ###\\n+\\n+\\n+def downgrade() -> None:\\n+    \"\"\"Downgrade schema.\"\"\"\\n+    # ### commands auto generated by Alembic - please adjust! ###\\n+    op.drop_column(\\'posts\\', \\'author\\')\\n+    # ### end Alembic commands ###',\n",
+       "     'commit_message': 'fix: cors 설정 및 DB 연동 마무리'}],\n",
+       "   'filepath': 'alembic/versions/c49e19c13dfb_updated_schema.py',\n",
+       "   'latest_code': '\"\"\"Updated schema\\n\\nRevision ID: c49e19c13dfb\\nRevises: 8532de57310b\\nCreate Date: 2025-03-11 11:22:03.149091\\n\\n\"\"\"\\nfrom typing import Sequence, Union\\n\\nfrom alembic import op\\nimport sqlalchemy as sa\\n\\n\\n# revision identifiers, used by Alembic.\\nrevision: str = \\'c49e19c13dfb\\'\\ndown_revision: Union[str, None] = \\'8532de57310b\\'\\nbranch_labels: Union[str, Sequence[str], None] = None\\ndepends_on: Union[str, Sequence[str], None] = None\\n\\n\\ndef upgrade() -> None:\\n    \"\"\"Upgrade schema.\"\"\"\\n    # ### commands auto generated by Alembic - please adjust! ###\\n    op.add_column(\\'posts\\', sa.Column(\\'author\\', sa.String(length=100), nullable=False))\\n    # ### end Alembic commands ###\\n\\n\\ndef downgrade() -> None:\\n    \"\"\"Downgrade schema.\"\"\"\\n    # ### commands auto generated by Alembic - please adjust! ###\\n    op.drop_column(\\'posts\\', \\'author\\')\\n    # ### end Alembic commands ###\\n'},\n",
+       "  {'patches': [{'patch': '@@ -1,8 +1,18 @@\\n from fastapi import FastAPI\\n+from fastapi.middleware.cors import CORSMiddleware\\n from post import router as post_router\\n \\n app = FastAPI(root_path=\"/api\")\\n \\n+# CORS 설정 추가\\n+app.add_middleware(\\n+    CORSMiddleware,\\n+    allow_origins=[\"http://localhost:5173\", \"https://jm-story.site\"],  # Vite 프론트엔드 URL\\n+    allow_credentials=True,\\n+    allow_methods=[\"*\"],  # 모든 HTTP 메서드 허용 (GET, POST, PUT, DELETE 등)\\n+    allow_headers=[\"*\"],  # 모든 헤더 허용\\n+)\\n+\\n @app.get(\"/\")\\n def read_root():\\n     return {\"message\": \"Hello, FastAPI!\"}',\n",
+       "     'commit_message': 'fix: cors 설정 및 DB 연동 마무리'}],\n",
+       "   'filepath': 'main.py',\n",
+       "   'latest_code': 'from fastapi import FastAPI\\nfrom fastapi.middleware.cors import CORSMiddleware\\nfrom post import router as post_router\\n\\napp = FastAPI(root_path=\"/api\")\\n\\n# CORS 설정 추가\\napp.add_middleware(\\n    CORSMiddleware,\\n    allow_origins=[\"http://localhost:5173\", \"https://jm-story.site\"],  # Vite 프론트엔드 URL\\n    allow_credentials=True,\\n    allow_methods=[\"*\"],  # 모든 HTTP 메서드 허용 (GET, POST, PUT, DELETE 등)\\n    allow_headers=[\"*\"],  # 모든 헤더 허용\\n)\\n\\n@app.get(\"/\")\\ndef read_root():\\n    return {\"message\": \"Hello, FastAPI!\"}\\n\\n@app.get(\"/health\")\\ndef health_check():\\n    return {\"status\": \"healthy\"}\\n\\n# Post 라우터 등록\\napp.include_router(post_router, prefix=\"/posts\", tags=[\"posts\"])\\n\\n'}],\n",
+       " 'username': 'wjdalsdk70',\n",
+       " 'code_summary': {},\n",
+       " 'patch_summary': []}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_mvp[146][\"inputs\"][\"input\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Schema 정의"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#===========Json Schema===========#\n",
+    "class CodeSummaryModel(BaseModel):\n",
+    "    code_summary: str\n",
+    "    # check_important_change: str\n",
+    "\n",
+    "#================================#\n",
+    "\n",
+    "def merge_dicts(x: dict, y: dict) -> dict:\n",
+    "    if x is None:\n",
+    "        return y\n",
+    "    if y is None:\n",
+    "        return x\n",
+    "    return {**x, **y}\n",
+    "\n",
+    "# patches 내부 형식 정의\n",
+    "class PatchModel(BaseModel):\n",
+    "    patch: str\n",
+    "    commit_message: str\n",
+    "\n",
+    "# files 내부 형식 정의\n",
+    "class FilesModel(BaseModel):\n",
+    "    patches: List[PatchModel]\n",
+    "    filepath: str\n",
+    "    latest_code: str\n",
+    "\n",
+    "class DirectoryModel(BaseModel):\n",
+    "    patches: List[PatchModel]\n",
+    "    latest_code: str\n",
+    "    filepath: str\n",
+    "    directory_summary: Optional[str] = None\n",
+    "    code_summary: str = None\n",
+    "    file_node_id: Optional[int] = None  # 파일 단위 node ID\n",
+    "\n",
+    "class DirectoryGroupModel(BaseModel):\n",
+    "    directory_node_id: Optional[int] = None  # 디렉토리 단위 node ID\n",
+    "    files: Dict[str, DirectoryModel]\n",
+    "    directory_summary: Optional[str] = None\n",
+    "\n",
+    "class TilModel(BaseModel):\n",
+    "    username: str\n",
+    "    repo: str\n",
+    "    date: str\n",
+    "    keywords: List[str]\n",
+    "    til_content: Optional[str]  = None \n",
+    "\n",
+    "# Input 형식 정의\n",
+    "class GraphState(BaseModel):\n",
+    "    username: str\n",
+    "    category: Optional[str] = None\n",
+    "    repo: str\n",
+    "    date: str\n",
+    "    files: List[FilesModel]\n",
+    "    til_content: Optional[str]  = None \n",
+    "\n",
+    "    directory_dict:  Annotated[Optional[Dict[str, DirectoryGroupModel]], merge_dicts] = None\n",
+    "    \n",
+    "\n",
+    "input_data = GraphState(**data_mvp[146][\"inputs\"][\"input\"]) # ** 연산자를 사용하여 딕셔너리를 키워드 인자로 전달"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 디렉토리 구조로 변환"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_directory(state: GraphState) -> GraphState:\n",
+    "    repo_prefix = state.repo\n",
+    "    grouped_by_directory = defaultdict(dict)\n",
+    "\n",
+    "    for file in state.files:\n",
+    "        dir_path = \"/\".join(file.filepath.split(\"/\")[:-1])\n",
+    "        normalized_dir = f\"{repo_prefix}/{dir_path}\" if dir_path else repo_prefix\n",
+    "\n",
+    "        grouped_by_directory[normalized_dir][file.filepath] = DirectoryModel(\n",
+    "            filepath=file.filepath,\n",
+    "            latest_code=file.latest_code,\n",
+    "            patches=file.patches\n",
+    "        )\n",
+    "\n",
+    "    state.directory_dict = {\n",
+    "        k: DirectoryGroupModel(files=v) for k, v in grouped_by_directory.items()\n",
+    "    }\n",
+    "    return state\n",
+    "\n",
+    "input_data = make_directory(input_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 코드 변경 사항 반영"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def annotate_code_with_patch(latest_code: str, patch_text: str, filename: str) -> str:\n",
+    "    # 유효한 patch 헤더 붙이기\n",
+    "    if not patch_text.startswith('--- '):\n",
+    "        patch_text = f\"--- a/{filename}\\n+++ b/{filename}\\n\" + patch_text\n",
+    "\n",
+    "    patch = PatchSet(patch_text)\n",
+    "    code_lines = latest_code.splitlines()\n",
+    "    annotated = code_lines.copy()\n",
+    "\n",
+    "    target_file = next((f for f in patch if f.path == filename or f.path.endswith(filename)), None)\n",
+    "    if not target_file:\n",
+    "        return latest_code  # 변경 없음\n",
+    "\n",
+    "    offset = 0\n",
+    "    for hunk in target_file:\n",
+    "        for line in hunk:\n",
+    "            if line.is_added and line.target_line_no is not None:\n",
+    "                idx = line.target_line_no - 1\n",
+    "                # 줄 내용이 동일하면 주석만 덧붙이기\n",
+    "                if idx < len(annotated) and annotated[idx].strip() == line.value.strip():\n",
+    "                    annotated[idx] = \"[+]\" + annotated[idx].rstrip()  \n",
+    "                else:\n",
+    "                    # 삽입이 필요한 경우에만 insert\n",
+    "                    annotated.insert(idx,\"[+]\" + line.value.rstrip())\n",
+    "                offset += 1\n",
+    "            # 삭제된 줄도 표시\n",
+    "            elif line.is_removed:\n",
+    "                idx = line.source_line_no - 1 + offset\n",
+    "                annotated.insert(idx, f\"[-] {line.value.rstrip()}\")\n",
+    "                offset += 1\n",
+    "\n",
+    "    return \"\\n\".join(annotated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 디렉토리 구조 시각화"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📂 \n",
+      "  └── Dockerfile\n",
+      "  └── .gitignore\n",
+      "  └── alembic.ini\n",
+      "  └── main.py\n",
+      "📂 alembic/versions\n",
+      "  └── alembic/versions/c49e19c13dfb_updated_schema.py\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 예시 input_data\n",
+    "filepaths = [data.filepath for data in input_data.files]\n",
+    "# 디렉토리 기준으로 그룹화\n",
+    "grouped_by_directory = defaultdict(list)\n",
+    "for path in filepaths:\n",
+    "    dir_path = \"/\".join(path.split(\"/\")[:-1])  # 상위 디렉토리 경로만 추출\n",
+    "    grouped_by_directory[dir_path].append(path)\n",
+    "\n",
+    "# 출력\n",
+    "directory_structure = \"\"\n",
+    "directory_list = []\n",
+    "for directory, files in grouped_by_directory.items():\n",
+    "    directory_structure += f\"📂 {directory}\\n\"\n",
+    "    for f in files:\n",
+    "        directory_structure += f\"  └── {f}\\n\"\n",
+    "        directory_list.append(f)\n",
+    "print(directory_structure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 디렉토리 분류 노드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "updated_directory_dict = {}\n",
+    "file_counter = 1\n",
+    "directory_counter = 1\n",
+    "\n",
+    "# 디렉토리 경로 순회 (입력 순서 유지)\n",
+    "for dir_path in input_data.directory_dict:\n",
+    "    group_model = input_data.directory_dict[dir_path]\n",
+    "    updated_files = {}\n",
+    "\n",
+    "    # 파일 경로 순회 (입력 순서 유지)\n",
+    "    for filepath in group_model.files:\n",
+    "        file_model = group_model.files[filepath]\n",
+    "        updated_file_model = file_model.model_copy(update={\"file_node_id\": file_counter})\n",
+    "        updated_files[filepath] = updated_file_model\n",
+    "        file_counter += 1\n",
+    "\n",
+    "    updated_group_model = group_model.model_copy(update={\n",
+    "        \"files\": updated_files,\n",
+    "        \"directory_node_id\": directory_counter\n",
+    "    })\n",
+    "    updated_directory_dict[dir_path] = updated_group_model\n",
+    "    directory_counter += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir_keys = list(updated_directory_dict.keys())\n",
+    "\n",
+    "updated_directory_dict[dir_keys[1]].files[\"alembic/versions/c49e19c13dfb_updated_schema.py\"].file_node_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## dictionary의 items() 메소드는 순서를 보장하지 않음\n",
+    "\n",
+    "# 디렉토리 구분 없이 file 번호 지정\n",
+    "@traceable(run_type=\"tool\")\n",
+    "def fork_directory_nodes(state: GraphState) -> GraphState:\n",
+    "    updated_directory_dict = {}\n",
+    "    file_counter = 1\n",
+    "    directory_counter = 1\n",
+    "\n",
+    "    # 디렉토리 경로 순회 (입력 순서 유지)\n",
+    "    for dir_path in state.directory_dict:\n",
+    "        group_model = state.directory_dict[dir_path]\n",
+    "        updated_files = {}\n",
+    "\n",
+    "        # 파일 경로 순회 (입력 순서 유지)\n",
+    "        for filepath in group_model.files:\n",
+    "            file_model = group_model.files[filepath]\n",
+    "            updated_file_model = file_model.model_copy(update={\"file_node_id\": file_counter})\n",
+    "            updated_files[filepath] = updated_file_model\n",
+    "            file_counter += 1\n",
+    "\n",
+    "        updated_group_model = group_model.model_copy(update={\n",
+    "            \"files\": updated_files,\n",
+    "            \"directory_node_id\": directory_counter\n",
+    "        })\n",
+    "        updated_directory_dict[dir_path] = updated_group_model\n",
+    "        directory_counter += 1\n",
+    "\n",
+    "    return {\"directory_dict\": updated_directory_dict}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 파일 단위 Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = AsyncOpenAI(\n",
+    "            base_url=\"http://34.44.52.194:8000/v1\", \n",
+    "            api_key=\"sk-noauth\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def code_summary_prompt(latest_code:str, language=None):\n",
+    "    return f\"\"\"\n",
+    "        당신은 {language} 코드 분석 전문가입니다. 다음의 내용을 숙지하여 항목에 맞는 코드 요약을 수행해주세요.\n",
+    "       다음은 소스코드의 변경 내용입니다. 각 코드 라인의 앞에 [+]는 추가된 줄, [-]는 삭제된 줄을 의미합니다.\n",
+    "\n",
+    "        [변경된 소스 코드]\n",
+    "        {latest_code}\n",
+    "\n",
+    "        요약 항목:\n",
+    "        - 사용 기술 스택: 언어 및 사용된 주요 라이브러리\n",
+    "        - 주요 기능: 이 코드 파일의 기능을 한 줄씩 나열\n",
+    "        - 프로젝트 내 역할: 전체 시스템에서 이 파일이 담당하는 역할\n",
+    "        - 변경 내용 요약: 이번 코드 변경을 통해 **무엇이 어떻게 바뀌었는지** 핵심만 요약\n",
+    "\n",
+    "        ⚠️ 출력 조건:\n",
+    "        - 각 항목은 반드시 `-`로 시작하는 개조식 문장으로 작성할 것\n",
+    "        - 변경 내용도 `-` 하나씩 줄바꿈하여 작성할 것\n",
+    "        - 문장은 간결하게 유지하고, 불필요한 설명은 포함하지 말 것\n",
+    "        - 자연어 설명이 아니라 **기능 단위의 요점 중심 요약**으로 작성할 것\n",
+    "        \n",
+    "        요약:\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def directory_summary_prompt(code_summary:str, category:str, directory:str):\n",
+    "    return f\"\"\"\n",
+    "    당신은 {category}의 코드 리뷰어입니다. 다음은 디렉토리(`{directory}`) 내 여러 파일에 걸쳐 적용된 코드 변경 요약입니다.\n",
+    "\n",
+    "    [디렉토리 내부 코드 요약 내용]\n",
+    "    {code_summary}\n",
+    "\n",
+    "    [제약 조건]\n",
+    "    - 동일한 목적의 중복 기능은 통합하여 요약합니다.\n",
+    "    - 기술 스택은 주요 구현 언어 또는 프레임워크 단위로 간단히 정리합니다.\n",
+    "\n",
+    "    [요약 항목]\n",
+    "    - 사용 기술 스택: 이 디렉토리에서 사용된 언어 및 주요 라이브러리\n",
+    "    - 주요 기능: 사용자 관점에서 이 디렉토리가 제공하는 기능을 한 줄씩 개조식으로 작성\n",
+    "    - 시스템 내 역할: 이 디렉토리가 전체 프로젝트 내에서 담당하는 책임 또는 기능적 포지션\n",
+    "    - 변경 목적 요약: 이번 코드 변경의 전반적인 목적, 개선 방향 또는 핵심 의도\n",
+    "\n",
+    "    [출력 형식]\n",
+    "    각 항목은 반드시 `-`로 시작하는 개조식 문장으로 작성하세요.  \n",
+    "    설명형 서술은 지양하고, **핵심적인 기능 단위의 명확한 요약**을 작성해 주세요.\n",
+    "        \n",
+    "    요약:\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def til_generate_prompt(date:str, combined_directory_summary: str):\n",
+    "    return  f\"\"\"\n",
+    "다음은 하나 이상의 소스코드 파일에 대한 분석 요약과 변경 이력 분석입니다. 이를 참고하여 마크다운 형식의 TIL을 작성해 주세요.\n",
+    "\n",
+    "[날짜]\n",
+    "{date}\n",
+    "\n",
+    "[코드 + 변경 요약]\n",
+    "{combined_directory_summary}\n",
+    "\n",
+    "⚠️ 출력 규칙:\n",
+    "- 각 줄은 절대 들여쓰기 없이 시작하세요.\n",
+    "- 헤더는 `#`, `##`로 시작하고 공백 없이 맨 앞에 위치해야 합니다.\n",
+    "- 본문도 줄 맨 앞에서 시작해야 하며, 불필요한 공백이나 탭을 포함하지 마세요.\n",
+    "- 마크다운 문법 이외의 코드블록(````), 따옴표(`\"`, `'`) 블록 등은 사용하지 마세요.\n",
+    "        \n",
+    "\n",
+    "TIL 작성 시 반드시 포함할 항목 (개조식):\n",
+    "제목: # 📅 날짜 TIL\n",
+    "### 📖 1. 오늘 배운 내용\n",
+    "\n",
+    "### 📚 2. 개념 정리\n",
+    "\n",
+    "### 🤔 3. 해당 개념이 필요한 이유\n",
+    "\n",
+    "### 💡 4. 개념을 활용하는 방법\n",
+    "\n",
+    "### 🛠️ 5. 문제 해결 과정\n",
+    "\n",
+    "### ✍️ 6. 하루 회고\n",
+    "\n",
+    "작성 시 포함해야 할 항목 외에는 작성하지 마세요. 1번 항목부터 순차적으로 작성하세요. 들여쓰기는 없어야 합니다.\n",
+    "        \n",
+    "TIL:\"\"\"\n",
+    "\n",
+    "combined_summary = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_code_summary_node(file_node_id: int):\n",
+    "    @traceable(run_type=\"llm\")\n",
+    "    async def summarize_file_node(state: GraphState) -> dict:\n",
+    "        print(file_node_id)\n",
+    "        # file_node_id에 해당하는 grouped_model, filepath, directory 찾기\n",
+    "        for directory, file_group in state.directory_dict.items():\n",
+    "            for filepath, grouped_model in file_group.files.items():\n",
+    "                if grouped_model.file_node_id == file_node_id:\n",
+    "                    target_model = grouped_model\n",
+    "                    target_filepath = filepath\n",
+    "                    target_directory = directory\n",
+    "                    break\n",
+    "            else:\n",
+    "                continue\n",
+    "            break\n",
+    "        else:\n",
+    "            raise ValueError(f\"file_node_id {file_node_id}에 해당하는 파일이 없습니다.\")\n",
+    "        \n",
+    "        latest_code = annotate_code_with_patch(latest_code=target_model.latest_code,\n",
+    "                                               patch_text=target_model.patches[0].patch, \n",
+    "                                               filename=target_model.filepath)\n",
+    "        # LLM 요청\n",
+    "        messages = [{\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": code_summary_prompt(latest_code=latest_code, language=None)\n",
+    "        }]\n",
+    "        \n",
+    "\n",
+    "        request_payload = {\n",
+    "            \"model\": \"google/gemma-3-4b-it\",\n",
+    "            \"messages\": messages,\n",
+    "            \"temperature\": 0.1,\n",
+    "            \"max_tokens\": 512,\n",
+    "            \"top_p\": 0.95,\n",
+    "            \"stop\": ['<|im_end|>']\n",
+    "        }\n",
+    "\n",
+    "\n",
+    "        response = await client.chat.completions.create(**request_payload)\n",
+    "        summary = response.choices[0].message.content\n",
+    "        original_model = state.directory_dict[target_directory].files[target_filepath]\n",
+    "        updated_model = original_model.model_copy(update={\"code_summary\": summary})\n",
+    "        state.directory_dict[target_directory].files[target_filepath] = updated_model\n",
+    "\n",
+    "        return {\"directory_dict\":state.directory_dict}\n",
+    "\n",
+    "    return summarize_file_node"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 디렉토리 분석 노드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "for directory, file_group in input_data.directory_dict.items():\n",
+    "    # if file_group.directory_node_id == directory_node_id:\n",
+    "    target_directory = directory\n",
+    "    group_model =  file_group\n",
+    "\n",
+    "for filename, dict_model in group_model.files.items():\n",
+    "    print(dict_model.code_summary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_directory_summary_node(directory_node_id: int):\n",
+    "    @traceable(run_type=\"llm\")\n",
+    "    async def summarize_directory_node(state: GraphState) -> dict:\n",
+    "        # file_node_id에 해당하는 grouped_model, filepath, directory 찾기\n",
+    "        combined_code_summary = \"\"\n",
+    "        for directory, file_group in state.directory_dict.items():\n",
+    "            if file_group.directory_node_id == directory_node_id:\n",
+    "                    target_directory = directory\n",
+    "                    group_model =  file_group\n",
+    "                    break\n",
+    "            else:\n",
+    "                continue\n",
+    "        else:\n",
+    "            raise ValueError(f\"file_node_id {directory_node_id}에 해당하는 파일이 없습니다.\")\n",
+    "        \n",
+    "        for filename, dict_model in group_model.files.items():\n",
+    "            combined_code_summary += f\"{filename} code: \\n{dict_model.code_summary}\"\n",
+    "\n",
+    "\n",
+    "        # LLM 요청\n",
+    "        messages = [{\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": directory_summary_prompt(code_summary=combined_code_summary, category=None, directory=target_directory)\n",
+    "        }]\n",
+    "        request_payload = {\n",
+    "            \"model\": \"google/gemma-3-4b-it\",\n",
+    "            \"messages\": messages,\n",
+    "            \"temperature\": 0.1,\n",
+    "            \"max_tokens\": 512,\n",
+    "            \"top_p\": 0.95,\n",
+    "            \"stop\": ['<|im_end|>']\n",
+    "        }\n",
+    "\n",
+    "\n",
+    "        response = await client.chat.completions.create(**request_payload)\n",
+    "        # 결과 파싱 (예: structured JSON 반환한다고 가정)\n",
+    "\n",
+    "        ## 기존 grouped_model\n",
+    "        original_model = state.directory_dict[target_directory]\n",
+    "        # code_summary 필드 업데이트\n",
+    "        updated_model = original_model.model_copy(update={\"directory_summary\": response.choices[0].message.content})\n",
+    "        # 상태 반영\n",
+    "        state.directory_dict[target_directory] = updated_model\n",
+    "        return {\n",
+    "            \"directory_dict\":state.directory_dict\n",
+    "        }\n",
+    "\n",
+    "    return summarize_directory_node"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TIL 생성 노드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def generate_til_node(state: GraphState) -> dict:\n",
+    "    dir_file = state.directory_dict\n",
+    "    combined_directory_summary = \"\"\n",
+    "    \n",
+    "    for dir_name, group_model in dir_file.items():\n",
+    "        combined_directory_summary += f\"{dir_name}: \\n directory_summary: {group_model.directory_summary}\\n\\n\"\n",
+    "\n",
+    "    # LLM 요청\n",
+    "    messages = [{\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": til_generate_prompt(date=state.date, combined_directory_summary=combined_directory_summary)\n",
+    "    }]\n",
+    "    request_payload = {\n",
+    "        \"model\": \"google/gemma-3-4b-it\",\n",
+    "        \"messages\": messages,\n",
+    "        \"temperature\": 0.1,\n",
+    "        \"max_tokens\": 2024,\n",
+    "        \"top_p\": 0.95,\n",
+    "        \"stop\": ['<|im_end|>']\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "    response = await client.chat.completions.create(**request_payload)\n",
+    "    # 결과 파싱 (예: structured JSON 반환한다고 가정)\n",
+    "\n",
+    "    ## 기존 grouped_model\n",
+    "    original_model = state.directory_dict\n",
+    "    # code_summary 필드 업데이트\n",
+    "    updated_model = original_model[\"til_content\"] = response.choices[0].message.content\n",
+    "    # 상태 반영\n",
+    "\n",
+    "    til_dict = {\n",
+    "        \"username\": state.username,\n",
+    "        \"repo\": state.repo,\n",
+    "        \"date\": state.date,\n",
+    "        \"keywords\": [],\n",
+    "        \"til_content\": response.choices[0].message.content\n",
+    "    }\n",
+    "    return_model = TilModel(**til_dict)\n",
+    "    return return_model\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LangGraph 빌드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_counter = 1\n",
+    "dir_counter = 1\n",
+    "\n",
+    "builder = StateGraph(GraphState)\n",
+    "builder.set_entry_point(\"fork_directory_node\")\n",
+    "builder.add_node(\"fork_directory_node\", fork_directory_nodes)\n",
+    "builder.add_node(\"til_generate_node\", generate_til_node)\n",
+    "builder.set_finish_point(\"til_generate_node\")\n",
+    "\n",
+    "# 디렉토리 요약 노드 ID 저장용 리스트\n",
+    "dir_node_ids = []\n",
+    "\n",
+    "for dir_idx, (dir_path, group_model) in enumerate(input_data.directory_dict.items()):\n",
+    "    # 디렉토리 내 파일 노드 추가\n",
+    "    for file_idx, file_model in enumerate(group_model.files):\n",
+    "        file_path = file_model  # file_model이 str인 경우\n",
+    "        file_node_id = f\"summarize_file_node_{file_path.replace('/', '_')}\"\n",
+    "        file_summary_node = make_code_summary_node(file_counter)\n",
+    "        builder.add_node(file_node_id, file_summary_node)\n",
+    "        builder.add_edge(\"fork_directory_node\", file_node_id)\n",
+    "        file_counter += 1\n",
+    "\n",
+    "    # 디렉토리 요약 노드 추가\n",
+    "    dir_node_id = f\"summarize_directory_node_{dir_path.replace('/', '_')}\"\n",
+    "    dir_summary_node = make_directory_summary_node(dir_idx + 1)\n",
+    "    dir_node_ids.append(dir_node_id)\n",
+    "\n",
+    "    builder.add_node(dir_node_id, dir_summary_node)\n",
+    "\n",
+    "    # 각 파일 요약 노드 → 디렉토리 요약 노드 연결\n",
+    "    for file_model in group_model.files:\n",
+    "        file_node_id = f\"summarize_file_node_{file_model.replace('/', '_')}\"\n",
+    "        builder.add_edge(file_node_id, dir_node_id)\n",
+    "\n",
+    "# 디렉토리 요약 노드 → TIL 생성 노드 연결\n",
+    "for dir_node_id in dir_node_ids:\n",
+    "    builder.add_edge(dir_node_id, \"til_generate_node\")\n",
+    "\n",
+    "graph = builder.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAB3AAAAIMCAIAAACLxqoMAAAAAXNSR0IArs4c6QAAIABJREFUeJzs3Xd4VGXax/Fn+kwmySQhgfRCKAEEBEGJIE1BsGEBEUV0WXtZsLvuKqjYG66KYn9BcUFRFBFFRCkiKr33VEghIT2ZPu8fR88eJ2EYSnJSvp+Li2tyMnPmPpNp+eWe+9H4fD4BAAAAAAAAAMDxaNUuAAAAAAAAAADQMhAoAwAAAAAAAACCQqAMAAAAAAAAAAgKgTIAAAAAAAAAICgEygAAAAAAAACAoBAoAwAAAAAAAACCops+fbraNQAAADQWrxAaIRYXZq0pLUywWN/L2ZlTW3VGeLv8uuoPcncV2Gu7hUUerKmYk7en1GXvEhqxt7r8o7w9lW5nutW2rbL0v/n76jzuNGv4hvLiTw/t9wmRZAldd7Rw4eEDeq023mxdXXp4UcFBi04faw5ZXpy3uDA73GCMMVmWFmZ/U5QTY7REGc1fFWZ9W5Qbb7baDKaFhw98X5yXGhIWqjfOy9u7oiS/c2hEiE7/Ye6ulSWHzwhvZ9TqPszdtamipI8txuPzuXw+vUaj9q0IAAAAAH/Qq10AAABAo1h7tGBZUd7taWeE6PWH7TVhemOt2x1vttoMxlKnvc7jjjdbw/XGUqfd5fXFm61hOkOp0+72euPN1hCdodRp9/l88WarRacvddq1QhNvtuq12lKnXafRxJutWiFKnXaTVhdvtgohSp32EJ0h3mz1+nylTnuo3hhvtrp83lKnPUxniDdbnV5PqdNuMxi9Pmutx13qtEcZTQatttrtEkLEGC1WnaHC7XR4PdFGS5XbWe5yOH3eKVtW9QiP+nfX/mrfnAAAAAAghBAan8+ndg0AAACn04GaimRL2P/l7uoWFpURFql2OadqT1VZj/CoAzWVpU77iPZJapcDAAAAoE0jUAYAAK2Hy+d9Ye/G4TGJnUMj1K7lNPMK8eXhA6nW8AtiyJQBAAAAqIZAGQAAtBI+IbZWlAghEi2hatfSWCrdzg6mkCJ7bZo1XO1aAAAAALRFWrULAAAAOA3y66q/KcxOtIS24jRZCBGuN9Z53LOztxc6atWuBQAAAEBbRIcyAABo8bZWlHxblPv31O5qF9J0Cuw1KSHhYXqD2oUAAAAAaFsIlAEAQItX43bZvR61q2hqhfbajLBInUajdiEAAAAA2hBGXgAAgJbthyP5R5x1alehglqP+4V9G9WuAgAAAEDbQqAMAABasGVFuQdrKsP0RrULUUFHa3hmVOzBmgq1CwEAAADQhjDyAgAAtGC/Hi1KtYbr2/DYh1CdwaTTqV0FAAAAgLaCDmUAANCCdQ2LaMtpshBiTt7uLZUlalcBAAAAoK0gUAYAAC3V8/s27qg82sRX+tXn8/51/80neimfz3fZyLMOHthz2utJt9qWF+ed9t0CAAAAQIMIlAEAQIvk8vm2lJdkhEU28fUu+uyj9M7dT/RSa9f8cLSkODWt82mvp7ctekxs2mnfLQAAAAA0iBnKAACgRXL7fKVOeyPNu6irq/3vR+/8vm7Vrh1bYuMSBw6+YOKNd+h02gsGZkhnSEnrtOCrNaUlxfM/fufXtauyDuxJTet89XV/v+Tya4QQHo9nSP/Uex+a8eXn8w7l51x82dX//eht6YJPPPfmhRddcXqrNWp1YXrD6d0nAAAAADRIr3YBAAAAJ0Ov0Zi0Wk/j/Gl8/sfvzvu/N6c9/VqPnn1Ligufn/GQo67uvkeeevH1OfffNenrHzbHtI8VQrz28hMbf1/7yPSXO3ftvvTrz558dGpcQvJZ/c89lJ/jcrkWLvi/G2+eMnDwBSEh1i2bf+ua0fOf015ojGrn5u7uHh41NDqhMXYOAAAAAEoEygAAoEWan7/P5fWMjk1tjJ1nH9yb3ilj0OARQojIyHYznp8dYrUKIQ7u2xMWHiGlyUKIex+aUV1VGZ+YLISYcP2ts197bu/ubWf1P3ffnu1CiPHX3TRi1BjpnPv37Lj4sqsbo1QhhEWnK7TXNNLOAQAAAECJQBkAALRIXiGsBmMj7fzSMdfccdPYJx+dOvriq846Z1CHuD+af/fv25nRvZd02ufz/fD94mXffFFWWpJ1cK+0MTomVghxcP+eiMioi/5MkHNzDrpcrs5dezRStRfFpkUZTY20cwAAAABQYlE+AADQIk1I7Dy4XXwj7fyscwb9Z/b8osLDd986/oarR+7auUXafnD/nk6d/xij/OIzjzz/5EPnDR353rwlv24rfPL5t4QQ6Z26CiH2793do+dZev0ff7nfv3eHEKJLxhmNVK3X52uk0R8AAAAA4IdAGQAAtEjlLkeV29V4+z/n3CGvv7Pg44UrIqKibp54ScmRIq/Xe2Dfrk5dugshamtrFn0692+3TL120m1Wa5iUGhuNppS0zkKI/Xu3d+zUVd7Vgf174hOTQ0KsjVTqlwUHlhXlNtLOAQAAAECJQBkAALRI2yuPLjy8vzH2XFR4aPPGX6XTHTtlTH3gcZfLdaSoIPvgXp/PJyXF5UdL3W53Smon6WxOp2PFd4u7ZPTQ6XS1tTX5eTmdOneTd5i1f09aWpfGKFVS43Ynh4Q13v4BAAAAQEagDAAAWqSuoRHVrkbpUP7svx9Mf+Su5d99VVFetm3L+ldfnB7VLqZj54yy0hIhxN7dO3JzDkZ3iLVYQn5YtlgIUVRw6JH7btHpDe2iY4UQB/btEkJ06vK/QLnsaElNTdWGX9e43e7GKPi2tDPOtEU3xp4BAAAAwI/Gx8Q9AADQMjm9nsaYelFXV/uflx5f9OlcIURiclr/Aeddf+OdcQlJTqfjoSl/W7tmxf2PPD1uwuRf16589skHDufnJqemP/HcrN/Wrpr16lNDhl+UOWjYS888smp9jlb7x1/uV3y/+LknH9Lp9N/8uPW0V+v2+WrdrjRr+GnfMwAAAADUR6AMAABaqkP2mlq3K8poVrsQNX1fnOcR3usSuwZxXgAAAAA4VXq1CwAAADhJPp9vbt6eKem9j3WGtatXLP92Uf3tZWVHIyOjGrzI1AefCLdFnNYy/7ByxdKVPyxt8FsWa2hdTXWD3+rTL/PSKyYE2G1eXfVNqd1PU40AAAAAcBx0KAMAgBbsu6LcWHNIoiVU7UJUE2Ew6TQatasAAAAA0FawKB8AAGjBLuyQ3MlqU7sK1XxVkOXwetSuAgAAAEAbQqAMAABatt/Li5cX56ldhQoWHt4fZwkJ0THBDAAAAEDTYeQFAABo8WZnb+8e3q57aKTahTQdu9cdqjPYDCa1CwEAAADQthAoAwCA1sDh9eTUVLYzWdQupCnsqjqaZAlNCQlXuxAAAAAAbQ4jLwAAQGtg0ur21JSvPVqgdiGN7oij7reyItJkAAAAAKogUAYAAK3EpbFphXU1Xp/P00o/gFXldnl9QiPEvZ36qF0LAAAAgDaKkRcAAKBVcft82ypKtlSWjGifbNbq1C7ntPmp5NBPR/Jf7T2EdgAAAAAAKiJQBgAArdA3RdmVLuelcWlbK0qNWl1ySKhWaNQu6oSVOO3bKkoijKbB7RI2VRw5J7KD2hUBAAAAaOvocQEAAK3QRR1Sr0nsYtUZ9BrN8uLctaUFVr1hScHBKVtX76spt+j0s7O2T9m6Oq+22qLTv3pgy5Stq4846iw6/XN7N07ZurrK7bTo9E/s+W3K1tUOr8ei0/9z5y9Ttq7WaDQWnf7ebWvu3bbGotPrNJpb1n33z52/WHR6t883Zevqabt/tej0VW7nlK2rn92z3qLTH3HUTdm6+tUDWyw6/aG6milbV8/O2m7R6ffVlE/ZuvqD3F0WnX5bZemUravn5e+x6PTry4tf2r/p68KsML1hT9VRjxBn2mKMWi1pMgAAAIDmgA5lAADQVlR6XA6322YwGbXaCpfT6fVEGE0Gjbbc5XB5vZFGs16jKXM53F5vO5NZKzRHnXaPz9fOZNEKUeq0e32+aJNFI0SJs04IEW20eDyeQReN+nrx4nZGs1eIUkedTqOJMpq9wlfqsOu12kiDye3zlTntBq02wmBy+bzlTodRq7MZjE6vt8LlMOl04Xqjw+updDnNOn2Y3mD3emrd7lC9wajlD/8AAAAAmh0CZQAAgJPk8XgGDRr0yy+/qF0IAAAAADQROl8AAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAA4CRpNJquXbuqXQUAAAAANB0CZQAAgJPk8/n27NmjdhUAAAAA0HQIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUAmUAAAAAAAAAQFAIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUAmUAAAAAAAAAQFAIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUAmUAAAAAAAAAQFAIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUjc/nU7sGAACAFqZPnz4ajUaj+ctbqY0bN6paFAAAAAA0OjqUAQAATlhcXJxWq9VoNNo/xcbGql0UAAAAADQ6AmUAAIAT1q9fP2VvstfrPfvss1WtCAAAAACaAoEyAADACZs0aVKHDh3kL+Pi4m644QZVKwIAAACApkCgDAAAcMI6derUv39/+cv+/funpaWpWhEAAAAANAUCZQAAgJNx/fXXt2/fXgjRvn172pMBAAAAtBEEygAAACdDblLOzMykPRkAAABAG6FRricDAAAQpG2VpVk1leUuR53HrXYtqqmoqPjhhx8uuOCC8PBwtWtRTYhOH2E0pVltZ4RFqV0LAAAAgEZHoAwAAE7YC/s2VrldWo0m2mhx+zxqlwM1GTXaIkedT4gIg+neTmeqXQ4AAACAxkWgDAAATswzezdYdLoBkbFqF4Lm5efSAp/w3d+5r9qFAAAAAGhEzFAGAAAnYE7uboNGS5qM+ga2i/MIMS9/r9qFAAAAAGhEBMoAAOAEfHH4QP/I9mpXgWaqny1m0eGDalcBAAAAoBERKAMAgGAVOGo6mENMWp3ahaCZsuoN4XpDidOudiEAAAAAGguBMgAACFa12+1VuwY0c14hqlxOtasAAAAA0FgIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUAmUAAAAAAAAAQFAIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUAmUAAAAAAAAAQFAIlAEAAAAAAAAAQSFQBgAAAAAAAAAEhUAZAAAAAAAAABAUAmUAAAAAAAAAQFAIlAEAQCNyOuzvPz/t1gvPmTSox96tG0/04m9Mu39iZsaCN18+lRqmXnn+xMyMjWt+FEKs+HL+xMyMx2+99lR22JocOZw/MTNjYmaGo65W7VoAAAAAtAAEygAAoBGtWDR/xRfzvW7PZdffHB4RpXY5IiIqJqNP/5TOGad3t7OmP3D3pUNO7z4BAAAAoBnSq10AAABozarKjgoheg8cMvbWqWrXIoQQfc8b3ve84ad3n26Xa+PqFZaQ0NO7WwAAAABohgiUAQBAY3n9sfvWfb9ECLHu+yXrvl9y34tv9Rk49EjBobmvPJW1a0d1RVlUbNyZmUOuuet+g8EohLhl5Dm1VRUPvPT2soUfZe3eMWvJz8q91dXU/OuGy4sP5U1++PHhY8YHuN6s3dvff25a3oG9BoNpwj8e0Gq1Qgjp/xVfzn//2Wmde/WdNntezr5d/5p0RUR0+9see3buy08ldepy15OveDyeL959bcOaH4vyc7r2OmvUNTf2zjxP2m1p0eE5Lz+dvXdnxdHSpPROAy+8bNT4G37/admr//yHEMJeWzMxM2PcbVPH3HCb01437/UXtq5bfbS40BYZndK12w33P9qufZwQ4tv5//fRzGcGjLi48xm9v3h/1rAxVy+e87ZWq5297FeLNUwIsX/Hluk3jdcbTW9+s9ZitR7rGF956K4Nq5ZPfuhxoRE/fflZQU5W934DbnvsGWknAQoQQqxa8vmXH75VlJ/bPj7pmrvulzZqtFohRIDDBwAAAABGXgAAgEbUb8iIrr3PEkIkpne5fPIdcUmplWVHp988fuPqFeGRUUMvG1dbVfHdgjlvTn9QOr/BaBBCzHllRvaenZ3P6KPclc/ne+Oxe4sP5V149aTAabLL6Xjpgduzdu+Ijks4d9QlH7/6bGXZ0QbPqTcYpSB41mP3eX3e+NR0IcRbTzy06MO3NBrNBVdem39w/wv33vzbj99J558945ENq5abQ6yZ54/O27/3o5nPLP3vh/Gp6YNGjxFCmEOsl0++Qzrelx64c/nCeU6HY/iY8SaLZePqFU/ccq3TXieEMBhMUuQ995WnOyQkp3fvmdath9fr3bBqhXQt2379WQjRf+iIAGmyEMJgNAohVn39+fefzUvunOFw1G1Ytfyzt1+TvhuggOy9O9+e8UhRfm63vmd37H7Gu08/qtxtgMMHAAAAADqUAQBAIxpw/qjcvTv3bNmQlN5l7M3/EELMf/OlitKS5M4ZT3zwmU6nO/+qCQ9fe8lvK77N278nqVNXrUYnhAgNj3j248UGo0kIodFopP8Xvvva5rUre54z8LopDwe+0g2rVpSXHDGazY+/O98aZus9YPDLD94hRdJ+59RpdVKgPPiiKybd928hRPHhvF+WfS2EmPLUqx2SUs6/csJ9Y0d8/t4bZw+7cOf6dTvXr7NYw558b4HRbOl21tlvz3jkm48/GH3NjYMvumLN0i8tIaHSMW75ZfWO9Wt1ev2MDxZGRMe4XM77rx5VWnj4p8WfjRx3vUanEUIU5eVMffa1fkNGCCEqSkuzdu3YvPYnKZje/tvPQohBo8YEPkypobiirPT5T5YYjKbo2PjP3n51+/pfjlvAT199KoTo0vusf70xRwjx8X+eXfrJh0II4fMFOPxTvSsAAAAAaC3oUAYAAE1n67qfhRBnDT5fp9MJIRLTOiWkpgshdmxYJ59n8MVXSmmynAJv+23tovdnCSFun/6CNLkigIO7tgkhuvY+yxpmk4Ymh0VEyNl0g86/aoJ0Imv3DiGENdzWISlFCNEhISksMir/wN7qivLtv68VQnTu2dtotkhFfvTL7tcWr2zgGH9dLYTo0qtvRHSMEMJgMJ557mAhxI71v8rnsbWLltJkIcTAUZfpjaYta1d7PB57be2+7ZvDIyJ7DRgUzO3ZZ+Aw6bZK69pDCFFdUXbcAg7s3CaE6J05WL61/9iXRhPg8IMpBgAAAEBbQIcyAABoOtWV5UIIW2S0vCU8qt2h7APVlRXylujYeL9LSRmxEOKnLz+77IZbAl+FvaZaCCGNEpaEhNmqysu9Xu+xLtI+PvGPy9bWCCFqKismZmYoz3CkIL/sSLEQIiQ07Bj7+J+aygohhC2q3f+OMbKdEKKm6n/HGBObIJ82h4QMOP/CNUu/2rPp99qaSq/HM+iiKwLE30pmi0U6YbRYhBDSMQYuQDpGi/WPJQSt4eHSCZ/XG+DwQ20RwdQDAAAAoNUjUAYAAE0nPDKytPBwTXWlvKWq7KgQIjwySt6i1ev8LpWW0WP0hL/Nmnb/V3PeGnLpVcqotD6zNVQIUVP5v6uoraqQF+VrkEb7xzVaw8KlFt0pT72qPEP7hKSQsHAhRE1V5TH2oTjGiCi/c1aVH5W3/3GNur8c49DLxq1Z+tWmtT85HXYhxJBLrzrutfjxeb1CCI3Pd9wCzCFWIUTtn9+VbyiNVhvg8E+0HgAAAACtFSMvAABA0+mdOUQIsX7lMqmXNm//nvys/UKI3uec1+D5pUbdXucMOnfkJb0zz7PX1s6f9VLgq0jt2l0IsX/HprqaKiHEzg2/VpUHO7GhY/deUthqi47p3m9Al95nZe3dWVleFhIantK1uxBi37bNdTU1Qojtv6+dmJlxx8UDfT6f0GiEEE6nXdrJmecOEULs2rReamp22us2rFwhhAgwxSLjzP7RcQmb167c/tva1K49pDEgJy1wAdLts2XdaunMv674NpjDP5V6AAAAALQmdCgDAICmM2r8DasWf561a8djk8d1OqPXL99/I4Q4/8prpKG99UkzlKX/J055ZOu6i1Yt+XzEuOukkcEN6jtoeKgtorqi/NHJ47qfdc665d9aw201ipEaAUTFdDj3wkvXfrf4qTsnDb9s3N7tW3au/6XPoGEDLhh9zrCRSz/5IG//nsf+PrZr735rvv1KCHHd3Q9pNJqomA7SpIj3n5/Wve+AAReM7n3u4C1rVz02eVz/oSO2/ramrKQoMb3LoNGXB7jq4WPGL3jrZSHEcVcdPK7u/QYEKOC8i674cdGCfVs3PnXnJFtUu92b1wdz+KdYEgAAAIBWgw5lAADQdELDbdPemdc787ycvTuXL/zE5xNX3XT3Dfc9Fsxl41LShlw6Vgjx4fOPBzibOSTknudet7WLLszNXrf82+unPiKNSHa7HMFcy40PTBt2+dVup2vRh29l79l58cSbbnvsWSGEyRLy71lzBlwwuig/96evPo1oFz354ccHjrpMCBGbnJo58hIhxIov5ucf2COEmPrs6yOuuq6mumLZZx+VFBwaMOLif8+aqzcYAlxv38HDpY7sc0deGkydgQUooEvPPpPu+7feaNq18becfbvvnvGKdBGX0xHg8IPnsDtmzpz59NNP/+c//3nvvfcWLFiwdOnS1atXb9q0af/+/YWFhdXV1ad+gAAAAADUopFafgAAABpUXl5eUVFRWVlZXl6+t7p8TbTp1vReahfVCn35f299+tbMgaMuvX3aC2rXckrePLB1VKUIqa6rqqqqqampqqqqqqqqVpC2h4aGhoWFyf/LJ6xWa1hYmLxR3q7X87k6AAAAoFngrTkAAG2R2+2WkmKJfFoKjsvLyysrK6UtNpvNZrOFh4dHRETokuJ87XqqXbs4eqTov2+82OC3zGbL5IefaPKKTsmCN1/es2XDni0b9EbT2Fumyts/fPHx2mM0815929To2IQmrPEE6HS6AQP6p1kDjV32+XxSsixHzPKJkpKSrKys+hm0Xq9XBs1yGG21Wuun0mFhYWazuQkPGgAAAGhDCJQBAGhV7Ha7XyKsbDGWtpeXlzudTptCRESEzWaLjo7u2LFjREREREREeHi4tF258301FS/s26jWocmiYjrcMb1lt/EqHco+sGfLhrSMHlfffm9M3P9i4hvvn6ZqXY1Io9FI6XDwF7Hb7cpmZ2XiXFhY6Le9qqrK7XYrQ2e/bugGM+jGPGIAAACg9SBQBgCgZaiqqlI2FNdvJZaCY61WK6XDUk+xlBcnJiaGh4dHRkbK261Wq8rHgz/d89wbapfQApjNZrPZHBMTE+T53W63lCzLkzfkaRuHDh1SbpfDaDl39gualVuUEzkMAYdiAwAAAK0VgTIAAGryer1+cycqKyvLysr8YuKKioqQkBBl47CUFHfp0kUKiOX42GQyqXxIQDOg1+ulXvvgL1J//ob0f2lpaU5OTv0MWqfTHWv0s3xCuT0kJKQxjxgAAABoIgTKAAA0CqfTeazZxMrhxdXV1VJArGwojoiISE5OVgbHNptNp9OpfUxAayZFwLGxsUGe3263K5cZVDY7FxcX19/ucDjqj36u3xOtzKC1Wm0jHzQAAABwwgiUAQA4MbW1tfVz4frBscfjsdlskZGRUk+xlBfHxsZ26dJFGROHhwdauwxAsyVN4YiOjg7y/B6Pp/5ig1LofPjw4frbq6urLRbLcZcflLZHRESEhobq9by3BwAAQKPjTScAAH+o30rc4KJ2BoNBuWyd1EecmpoqB8TSdy0Wi9oHdNqUlJTk5OTk5uZuKy2yn5Gidjlo1txud3Z2dnynrkxf8aPT6U50Coc8/bm6ulrZ7FxeXp6Xl6fMoKWPO+j1+lAFZfqsHAAtT4tuTU9TAAAAaDIEygCAVs7tdlcoyM3FfsFxeXm5MiCWo+G4uDi5xVha1K51r8RVXV2dm5ubl5eXm5ubk5OTl5eXk5NjtVpTUlKSkpJsnVJpgURgHo/nrbfeemzztqioqJSUlOTk5NTUVOlEhw4d1K6uhbFarSe0fqbdblc2QSvnQRcUFMiRtJxTu1yuwB3Q9Zci1Gg0jXnEAAAAaAE0Pp9P7RoAADgZdru9fkAsL2onnaioqKirq5PnSyiTYnmL/GVbC0q8Xm9ubq4cHEun7XZ7cj3yYmL7aipe2LdxcnI3lUtHM/Z29o5Hu/ZPs4YXFBRIje05OTnZ2dm5ubmVlZUpf5LuWqmpqWazWe2S2y632+2XPvutSVh/ErTc3ewXNyu3KDPo1v0XOAAAgLaJJiMAQLMjfaBbbhxusL+4oqJCCKFMhKX/4+Pju3XrpgyOQ0ND1T6gZqGoqEhqN87906FDh6S+45SUlB49eowaNSo5OTn4gbBAYHFxcXFxcQMGDJC32O327Oxs6U64atWq3Nzc7OxsaQnKlJSU1NRU6UTwy+LhFOn1+hOdwuGXMstfHj16NDc3VzkYWjqh1Wr95mw0mEHLJ+Q/XwEAAKDZIlAGADQdecSEX0zsFxybzWZ5QrG8qF3Hjh39GoppbDyWqqoqKbNTJsg2my0pKSk1NTUpKenss89OSUlJTExUu1K0LWazOSMjIyMjQ7mxsLBQuotmZWVJKXNZWZncxSwPzWDabzMhJb/Bh/4Oh8NvCoecRBcXF9fvhnY4HMeavBEaGtpgN7QNhhcRAAAgAElEQVRWq23kgwYAAMBfECgDAE6Vy+VSJsL1ZxPL25WNw3JknJCQIA+gkDClN3hut1uedCwnyG63WwqOk5KShg8fLs0WIH9H8xQbGxsbG3v22WfLW+x2uzwrY82aNVIjc1hYWMpfxcXFqVk3gmMymUwmU/AfffB4PMqIWZlBFxQU1P9WVVWV2WxucNXBY2XQLBcJAABwipihDAA4prq6uoqKirKyMikaPtaidi6XS5kIy6f9gmObzab2AbV4BQUF8sAKKUcuKiqSx1YkJydLJyIjIxupgP3VZR/k7b60Q1oj7R+twFeFB29N65liCTu9uy0uLs75kxQxl5aWylMypC7m5OTkE1rCDq1DbW2t35yNmpoav25oZRO0z+fz6332m8JRP4lW+xABAACaFwJlAGiLGgyI5S3yonY6nc4vEa7fYhwREcHIy8ZQXl6eq5CXl5ednR0dHS0vlCflyAkJCU1ZldvnG/PL149m9G/KK0UL4hPiid2/LT33sia4LqfT6Rcx5+bmhoSEyPmydKKJHyNo/pxOp1/ErIye/WZDS1v8pj8fqxtaxudsAABA60agDACth8/nk0dMSIlw/WnF0pehoaHKhmJ5KrFfl7HRaFT5kNoGp9MpdRxLwbF0WqPRJP9VSkqKwWBQu1jxxO7fe9uiO5gYaIsGHK6r2V1d9kjXfmoVcOTIETlflk4UFxdLzcvKpf/oOUXwfD6f3OasbIJuMImWThsMhmNNgm6wG5qRRAAAoGUhUAaAFsDpdPoNI/abRCF9q6qqSm4cjoyMlFqJ5UXtlMMoWMJIRfn5+VJqLI+tKC0tlVopJdLYimY7IeSIo+7OLSvv7XSm2oWgOXph78b3zjo/wtCMZtS63e6srCz5ESc1MpvNZmW+zBqVOL3q6ur8mqAb7IaWud1u5ZRnvwy6wW5otQ8RAAC0aQTKAKCmmpqawKvYSds9Hk+A2cTK7WofEP7i6NGj8sAKqVkyNzc3NjZWiozlwcexsbFqV3piSlz2yeuXX5WQHmkwtTNafIL3Em2aRmhKnHXlTvuCQ/s/OvvCSH0zSpOPpaSkRJkv5+bmFhQUKGcxS+v+hYWd5knQQIPcbrdf+qz8sn43dHV1tV/c7JdH+3VDh4WFMYUDAACcRgTKANAo/KZMKFexU243Go3KoRN+oyfk4NhiYbxAc2e326V2Y3lyRU5OjsFgkILjpKSk1NTUpKSk5OTk1vFbvcPreT9758aKI1ohDttr1S5HTW63u3X8TE9aosXq8YmzImNuSumh02jULuckud1u6cGbo2A0Gv0i5qSkJLUrBYQQosEO6ADd0Dqdzi93lpPoBkdz8MYDAAAEQKAMACfA7XZLibBfT7HcVixHxgFWsVNubw4jcXES5EnHcoJcWVkphU1ScCx1H9Pe2Op5PJ5Bgwb98ssvaheCRlFaWiov9ydFzIcOHZIHZchL//HpEDR/dru9wdD5WKM5nE6n32KDx+2G1rTYvycBAIATRaAMAEL6RStAQCxvdzgcDQ6dqB8cq31AOG2kj8Yr5eTkJCYmSp+Ol8dWtG/fXu1KoQIC5bbG6/XK/cvy0n86nS5FQWpnVrtS4JR4PB6/pQiP2w0dEhLiN2fDarUG6IZm4V8AAFouAmUArVxVVZXfVOKysjJ5XTv5W1qtVpkIK4dOyKvb2Ww2lsFp3WpqauqPPLZYLFLrsbxoXkpKCn1YkBAoQwhRVlamHJQhPXX4dTEnJyfzt0a0bspZz8dKopVfajSaYw3cCA0NVXZDy1vUPkQAAPAHAmUALZLX65UzYr9ZE8oJxRUVFVarVRkQ+7USyxtNphawihROI5/PJw2skCdX5Obm1tbWJtfDb7AIgEAZDZKeYeShzNLQDCGEXxdzamqq2pUCqnE4HPUHbjTYDS2dqKurq7/YoM1mk/uglbM4pC/VPkQAAFotAmUAzYvD4Qi8ip20paamRo6DGwyI5e1arVbVA0KzUFxcnJeXl52dLQXHUg+y1HcsJTuS6OhotStFC0OgjOCVl5cru5ilE3IXs7zuX2RkpNqVAs2R1+v1W2ywqqqqsrJSPq2cxSGdJ8DCgw2OgW7jK6wCABA8AmUATaS6urr+SOL6wbHX65Wz4PqjiuXtrHWGY6murpbCGnlsRU5OTnh4uBTWSAmyNL9C7UrRGhAo4xQpw2WJ1+tVDsqQUmb+OAqchGMtPCj3QfuNgdbr9fUT52OtRhgWFmaxWNQ+RAAA1EGgDOBU+QXE8qhiv+1mszlAQCxvN5vNah8QWgyPxyNNq1AOr3A6ncqmYymO4X6FRkKgjNOuoqJCXu5PzprlhUCTk5PT0tKSk5OjoqLUrhRobex2e/2FB5VTof3mQbtcrvpDnwN0Q4eFhbEGAwCgdSBQBtAwl8tVUVFRVlYmJcL1A2I5OJYnTthstsjISOmE31p2ERERfIoQp6iwsDD3T1KCXFBQICcs8vAKQhY0JQJlNA35qU/Oml0ulzSFWfnxC4PBoHalQBvidrurFfy6nv1WJpSy6ZCQEHnE87EyaOV2o9Go9lECANAAAmWgzamtrfWbNeEXHJeVlVVUVLhcrsCtxNJ2m82m9gGhFZIa9PxERUVJoyqk4DgpKSkxMVHtStHWEShDLVVVVfJyfzk5Ofn5+dnZ2TExMSl/FRMTo3alAP5Huepggxm033aNRqOcvNHg6GflsoSsJAwAaBoEykDrEXgVO3m7Xq+XAmIpGj7WDIqQkBC1Dwhtgsvlknru5LXycnJyfD5fcj0mk0ntYgF/BMpoVg4fPiwv+ic1MtfU1CjzZWk6Mz2PQEvhcDgCj36Wt0un6+rq/Lqej5tB63Q6tY8SANDyECgDzZ3b7a5QqB8Qy9vDwsLkOFgiD6OQg2ObzcavkVDR4cOH5YEVUuRRUlKiHHksfWo7IiJC7UqBoBAoo5mrra1VRszS/+3atfNLmTt06KB2pQBOA6/XK4fOxxr97JdBm0ym4y4/qNzOuhQAAAJlQE12u11KhP2iYXlCsbTdbrc3GBDXD45Z5QPNSllZmRQc5+XlZWdnSwly+/btleM+k5OT4+Li1K4UOHkEymiJCgoK5BZmKWuurKyUxzFLT84sZwq0EbW1tcddflC53ePxHHf0s19btNqHCAA4/QiUgdOvuro6QEAsb9RoNPJUYnktu/rBMW/C0PzZ7XZpWoUUHEvZsU6nk4JjZYLM2oxoZQiU0TrU1dX5NTLn5ORERkbKY+uluDk2NlbtSgGozOVyHXf5Qb/t9ZudA2fQvF0EgOaPQBkIltfrrR8Qy2vZyRsrKipCQkLqjySuHxzT+IMWKj8/Xzm2Ii8vr7y8XBpYISfIycnJ4eHhalcKNDoCZbRihYWFfilzeXm53Mgs/Z+amsr7GQCByeM1lI3Px1qWsKqqSq/X1w+a/UY/K0NqnoUAoOkRKAPC6XT6NRQrRxXLW6qrq5Vr2cmtxPWDY5a2QKtRWloqRcbyonk5OTkJCQnywApp6jE9a2izCJTRptjtdilZll4OcnJysrOzbTabcsW/lJQUXhQAnAq73X7c5QeVYbTb7W5w9HOAZQnVPkQAaPEIlNGa1dbWyo3D9QNiOTj2eDwRERFyNKxMiv36i1U+HqAxSZ93zv0rk8kkZQTy5Irk5GStVqt2sUBzQaAMFBUVyY3M0omjR48q82XphMViUbtSAK2T2+0+7uhnv27oYJYfVG43GAxqHyUANC8EymiR6k+ZUEbG0v/l5eUGg0GKhpUjiZXBsbSd33DQBskDK6TZxzk5OdXV1ampqfLACgkjvIHACJSB+hwOh9845uzs7LCwMDlillLm+Ph4tSsF0Eb5Dd84bgat0+mOu/ygcjx0SEiI2ocIAI2LQBnNiMfjUebC0on6i9qVl5eHhYX5TZlQRsZycMxfkgEhxJEjR5QDK6T5FVLTsTy2Ijk5OSYmRu1KgZaHQBkIUnFxsXJQRm5ubklJSYqC9DkYq9WqdqUA4M9ut1crBFiWUNrocDgaHP3cYAYtfclHAAG0LATKaAoOh6PBVez8Woxra2uVMbEcDfvNLLbZbBqNRuVDApqlyspKOTvOz8/Py8vLzs4ODQ2V18qTTqSkpKhdKdBKECgDJ83pdMqNzPLEjJCQEOVE5uTk5ISEBLUrBYAT4/F4Ao9+rp9NWyyWYy0/WH+7zWbT6/VqHyWANo1AGaekurpa2TgsJcX1pxV7vd7Aq9hJX/LheiB4bre7/tgKj8cjZ8eJiYlSgsxQF6DxECgDp5f0qRqphVn6v6ioKC0tTZ7jL8XNvGkE0Moop234ZdD1t1dUVBgMBuXcZ+WJBpciNJvNah8igFaFQBkNCzybWG4xNplM9WcT10+KefUCTlFBQYHf2IqioiIpO5YGH0t9x5GRkWpXCrQtBMpAY3O73VILs3LdP7PZrByUkZKSkpiYqHalANB07Ha7FC7LKfOxYmiJ2+0OVfDLoBtMpdU+RADNGoFy2+J2u/1aiaVcuH5S7JcI+80mloNjPmgDnHbl5eVyx7F0Ijs7Ozo6Wh52LOXIfAQYaA4IlAFVlJSUKBf9y8nJKSwsVA7KSElJSU1NJRABAInb7fZbb7DBMFo6IZ1Hjp79RnAoTygzaMIBoE0hUG4l7HZ7g6vY+bUYO53OBodOhIeHR0ZGSiek7WofENAmOJ1Ov7XycnNzhRDJf5WSksIKk0DzRKAMNBPSJCg5Zc7Nzc3KyjKZTHIXsxQ0JyUlqV0pALQMfm3ODZ5QZtA6nc5v4IZy1cH6YTRz+YAWjUC5Jdm1a9eWLVsaDI61Wq2UDivXr1OuYidtZ+FsQHULFy48ePCg9LtuaWmpvEqe9FtucnIyf9EBWhACZaA5Ky0tVQ7KyMnJOXz4sNzIfN555/Xs2VPtGgGglbDb7VLKXL/fucEw2uVy1V9vUO53Tk9P79evn9rHBOCYCJRbjNra2gkTJgwdOrT+DAqbzWYymdQuEMDxLVq06JtvvhkxYoTUehwXF6d2RQBOidfrHTt27Oeff652IQCC4vF45Ih50aJFH3zwAX/HBQBVSFM4lBOflWH0hg0bnnjiiU6dOqldJoCGMeOmxfB6vdXV1ffcc4/ahQA4eZWVlb169Ro3bpzahQA4PXw+X0FBgdpVAAiWTqfr2LFjx44dhRDz5893u91qVwQAbZRer5eWaGrwuzfccIPL5WryogAES6t2AQAAAAAAAACAloFAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQCJQBAAAAAAAAAEEhUAYAAAAAAAAABIVAGQAAAAAAAAAQFAJlAAAAAAAAAEBQND6fT+0aEMiDDz64bNkyrfaP6F+j0fh8Po1Gs2HDBrVLAxCsUaNGHTlyxOv1ajQaeWN0dPSyZctUrQvAyevdu7dOpxNCSK/L0olNmzapXReA4zjzzDPlt9bS49fn8w0dOvSVV15RuzQAaOv69Okj5R7yFq/X26tXrzlz5qhaFwB/dCg3d7feemtqaqr2TxqNRqvVJicnq10XgBMwZswYjUaj0+mUj+Xzzz9f7boAnLwuXbpID2f5od2xY0e1iwJwfD169JBfjqXHb3x8/B133KF2XQAA0a1bNyn0kEVFRd15551q1wXAH4Fyc5eenn722Wcrt/h8vtGjR6tXEYATds011yQlJSm3JCYmXnPNNepVBOBUZWZmKttnfD7fsGHDVK0IQFBGjx5tMpmUW/r27du5c2f1KgIA/OG6667ze4ru2rXrOeeco15FABpGoNwCjB8/XhlFpaSkTJgwQdWKAJyYyMjIkSNHKrcMGjQoJSVFvYoAnKoJEyYoH8VpaWlXX321qhUBCMoVV1yh/LRfbGzsjTfeqGpFAIA/XHzxxcqPfNlstkmTJqlaEYCGESi3AOnp6fJf5LRa7ejRo8PCwtQuCsCJufrqq+X3RgkJCePHj1e7IgCnJC4ubvDgwXKT8tChQ9u3b692UQCOz2q1XnbZZXIHXN++fdPT09UuCgDwh0mTJlmtVunjX927d8/MzFS7IgANIFBuGcaNG5eYmCg1QJFDAS1Ru3btRo4cKS3hNWjQICahA63AVVddJTUp054MtCyXXnqp9EIcGxt73XXXqV0OAOB/LrzwQukpun379tdff73a5QBoGIFyy5Cenj5gwAAhxKhRo8LDw9UuB8DJuPLKKzt27JiQkEDwBLQOCQkJgwcPFkIMGTKE9mSgBQkNDR0zZoxer+/bt2/Xrl3VLgcA8BcTJ040m81dunTxW1AKQPOh8fl8Ab7t8Hm+OpyVX1dd4qxrwqrQALvdvmvX7p49e+r1OrVraeuijJbOVttlcWlqF3J8PxTn7a4ur3I7q9xOtWuBEEJkZ2c7na4uXVj5p1kI0enD9MYuYZGj2reAhvElRTl7qo5Wulwun0ftWvA/Todzx86dZ/ToYTAa1K4F/2PS6sP0hq5hkRd1aAHT6pcW5eytLq/yuOt4sW5CHo9369atGRldLRaL2rW0LVEGc6fQiDEt4Y30j0fyd1WVVbtdFW6H2rUAbc6WzVtS01JtNpvahQBtTozJkmgOHROfblCsQF5foEB5R2XpY7t+7WWLTjBbDVpCTOAPNR5XqcO+qeLIrN5DYs1WtctpmNvnu3/7mhijOURnaG+yuAP+6Qhom3QaUep0VLudeXXVr/YabGqur3TlLsedW1Z2C42MMJhsRqOXRzNwPFqNKHc6K1yOvTXlb/QeGqZvpnF/ncd915aVHUPCwwzGKIPZI3h4o/Wr9biPOGs3lBXP6j00wRKqdjkN8wrfA9vWRBktITpde3OIm5deAECb4fS6D9trN5UfeaZHZrewqGOd7ZiB8qby4g9yd1+b2KUxiwRaMLvXMz9/77+69k9sfm+FfT7fXVtWDYjq0Dk0Qu1agBbgsL3mm8Lst/sM1wb8G6wqKlyOB7b/fGV8eoTBpHYtQMtz1Gn/4vDBmb0HW3V6tWvx5/L5bt30w+VxHdubQtSuBWhqTq/nv/n7HuzcN9Xa7Kb5+Xy+e7at7h0R0y00Uu1aAABQzbz8vX9P6d7bFt3gdxsOlF0+700bf7gtrWez+8UaaE7KXI5vi3Je7TVY7UL8zTq4TafV9A5v+GEPoL591eWHHbUPde6rdiH+/rlj7dmRsXFm8ibgJOXVVW+pKJnRfYDahfibsWd9x5Dwjs0vTQOaRqXbuejwwTfOHNrcfuWcnbXdJ3xn2mLULgQAADV5fL53cna82+d8fUN9Vw0vyre2tKCDKaS5vbQDzU2kwVTrce+rLle7EH/LinNpqQBOSOfQiNUlh1w+r9qF/MVhe01eXTVpMnAqkiyh+2vKS5x2tQv5ixqPa0NZEWky2rJwvdEnxM7KUrUL8besOLcrb6QBAG2eTqOJNprXHS1s8LsNB8r5ddXN8FP8QDPU0RKWXVuldhV/caiuuqM13Nhcp8ECzVbPsHb7q8rUruIvsmoqO1tZigQ4VV1DIw/WVKhdxV8cqKnoHn7MmXRAG5FqCcutq1a7ir8odNQmW8IszW9IDgAATS/BHJp3jMir4UC5zOlg3QEgGE6fr8bjUruKv7B7PZXu5lUS0CJUe9z2ZtahXOtxOZtZSUBLZPd6aj1utav4C7vHU9fMSgKantvnqXI71a7iL+wed7nboXYVAAA0CxqNKHM3/Dm/hgNlAAAAAAAAAAD8ECgDAAAAAAAAAIJCoAwAAAAAAAAACAqBMgAAAAAAAAAgKATKAAAAAAAAAICgECgDAAAAAAAAAIJCoAwAAAAAAAAACAqBMgAAAAAAAAAgKATKAAAAAAAAAICgECgDAAAAAAAAAIJCoAwAAAAAAAAACEpbD5TfmHb/xMyMBW++fNr37HTY339+2q0XnjNpUI+9Wzcqr6goL2diZsbEzIzTfqUnYfYTD0/MzJj32vNNcF0Bbu3C3GzpNnG73U1QCVqHFV/On5iZ8fit1zbGzneuX/fo5LHXn9vtxftv87t/ThkzbGJmxrbffm6M6z0hK79eODEz49HJY096D0s/+VA6tImZGdef2+2uSwc/fsuEFV/OP/XaTuNPZ9mnc+8dO2JiZsbXH7+n3G2zei7FKWrUh/Ox7kKt7OEcwKzpD5zedzuBf153XzrkRG/V4O8A8hOyx+M5kZKhGh7djfroDl7j/daDFoo30kcO50uFOepqT/vOT/vNG3iHzf8B3vx/33/xvlulCn0+n7Rl1ZLPp980fvKwM++8ZNCr//xHVXlZMPspKTw0/abxEzMz7h8/Srm97Ejx64/eM/XK8/829MyHr73k52+/CrKw7z+bd+OQ3hMzM5QXcbvdi+e88+jfrrpxSO97x46Y/eQ/a2uqG7y4X+BzpODQi/fd+rehZ958QX+Xy3kS79lOr6lXnj8xM2Pjmh8baf+N+hLc/B93jU2vdgEqS0hNz+jTPzo+4bTvecWi+Su+mG8JCb3s+pvDI6Ia74paEL8bYdb0B3Zt+O21xSuFEAazKaNPfyGERqNRu0y0GBFRMRl9+id27NwYO5/5yJTaqoo+g4b1GTS01d8/jWZzx249PW533oG9+7Zt2rdtU9auHX9/+Am16xJCiJx9u+a8/JQQYsRV16V0znA5HI33Q4eKGu/hzF2o6XXueWZl+VFrqC34iwR/B2j1T8itD4/uZoJfRuCHN9KtSfN/gDfzu8HWX9dsXrtSuWXdD9++PeMRIURMfGJZyZHff1rm9Xrvee71wPvZuHrFW0/+s7aqwm+71+t97p6b8g/s1ep0MfGJ+Vn7Zz/5cHxqx7SMMwLsraaq4u0Z/9qwann9b30086nlCz8RQnRISinKyyk+lFdXUz312deOe6QfzXxm89qVield+g25QKNpMQ2mRwoO3XPl+ZMffnz4mPFq14L/aeuB8uV/u/3yv93eGHuuKjsqhOg9cMjYW6c26hW1IMobwe1ybVy9whISKn3Zrn3cv2fNVbU6tDx9zxve97zhjbFnj8cjvQ+49q4H41LShBCt+/7ZPi5RPsBV3yx6Z8Y/f/xyQVKnLiPHTlS7NCH1AkREt7/h/kelLY30Q4e6Gu/hzF2o6f3j6VdP9CLB3wF4w9Di8OhuJvhlBH54I92aNP8HeHN++Xa73XNfeUqr03k9Hjny/v7TuUKIYZdfPfnBx48U5P/7hqs2rFqetWdHWtceAXb19lOPdEhIPHvYTfPffEkZne/csC7/wF6TxfLUh1/EJqfOfeXp7xbMWfTBm/c890aAvf387Vdbf1k1/vb71n7/dd7+PfIO62qqVixaIIS4+6mZ5wwftX7l9zMfvnv9yu/LS45ERMcEPtiqijIhxMix1w2/vCUls2uXLVa7BDTgtAXK+3ds+ebj9/dt22yvreneb0CP/pkjx14nhFjw5stfzXk7c+Qldz7+ovS5knuuukAI8d6KjSZLyCsP3bVh1fLJDz1ur6tdvnCexRo2Yuy1g0aN+eCFx1cu/iw+peOVN/9jwPmjhBDBn1P6EPfaZYvzsw5ExbQ/c+DQsTdPsVitQohbRp5TW1XxwEtvL1v4UdbuHbOW/PzGtPt/Wfb1ZZNuufr2e19/9J51y5cqD+r8K6/52wPThRAHdm5d+M5/svbsNFtC+g254Kqb/mEOCQlwazx99992rv9FCLHu+yXrvl9y34tvrV32tXxFfmf2eDxfvPvahjU/FuXndO111qhrbuydeV7gWztn365/TboiIrr94+/+99PZMzf9vDIiKnrMjbede+Gl0hl2bvj109kzD+cc9LjdMfGJ519+zQVXTZC+VV1R/tYTD+3evN7psA8bM07aqNH+8bepEz3S+lZ/8+WiD2dVlZefdd7w8bffe9el5wkhZi/71Rpmk2/ttG5nvPrPfwgh7LU1EzMzxt029Zxho6SPhHy4erter/f5fJ+89vza75fo9Pohl1zZuWef56b8PaVzt6fmfCH/HJ/56Ku1y77+5fslXrcnc+TFE+56QCrgSMGhua88lbVrR3VFWVRs3JmZQ665636DwSjfiybd+6/8A/tWf7NoxpwvElLTV3/z5YovPsk7uDcupeO5Iy8Zfc2NJ3S8rYPTYf9u/txfV3x7KPtA+4SkXucMHHLp2MS0Tm63+8bzzhBCvDj/29jkVOkjM6uXLrro2snX3v3gt/P/76OZzwwYcfF5oy9f9OGbRwsLMi+8ZOwtU1Ysmv/RzKct1tDhl189/vb7hBDBn1MIcSj7wBfvvb5n88a62qqO3XtdNumWM/qfq9xJ5zN6f/H+rLE3T9Hqte8/O61zr77TZs87lH3goQkX+x3XG0t+tkW1qyw7Ou+1Z3dv3lBbXX3muYOvuvkfHRKSAtwauzf/PuP266XTD1wzumO3nndMf0F5//Q7/0k8agLfh532unmvv7B13eqjxYW2yOiUrt1uuP/Rdu3jhBA+n++jmc/8umJpecmR7v0y+5w7RAih/fNvyyfxZFLf4IsuP3Rw35KP31sy9z05UF726dwfFi04cjjPbLZ0SEqdcOf9XXqfJX2rtOjwnJefzt67s+JoaVJ6p4EXXjZq/A31dyu9yzl7+Kh/PDVTeqJo8HHn9yw94qrrFr7zHyFEeUnxxMyMi6/7e4ekZPmHXv9aeDhLP5HFc9/Z9tvao8VFqV269Txn4Mhx14eG27b99vNzU/4eGd1B+lyI9BGzkoJD977wZt9Bwxrp4bzp55+WfvJB1u6dJos548x+Y2+eIj2T1H823rNlvfyTXb7wkw9ffFx5UAmp6c99skQIcaIP5y/en9Wod6HjvhwHeEkK/HA+0SMNfIP7Odaz1gm915J+49q7ZcOXc2bv3vR7fGr6rY8+m5jWSRp5UVZS9NCr7/U8e6D0nmTRB7PyD+x1OV1p3To9U0cAACAASURBVHtefO3k+k9NK76cr/y5BHiSLMzNlp6Q/2/NDp1Od9zbpDXh0a10oo/u0/5ifdKP7pN4sT4tPxrlbz3Hfe6S5e3f88/rx4SEhk995j8f/+e5grysyOj2426dOuCCi6SdaLXa2ct+tVjDpN8Hp980Xm80ffDT5ubZhNhIGvuNtPzz+vcbcz5548Xdm3/vNeC8a+96sDA/57V/T62rqel1zsA7pr9gsoQ0xhvpE73HNuc30tIQgy8/fKsoP7d9fNI1d90vbZR+Fz65N9JBvvIe6ynuhB7dAV55lQ/w4N+fy+a/+fLiOW9375f5yGsfSFu+nvvOf2e9lNbtjCff/+xYt4x8z7ztsWfnvvxUUqcudz35yrFequSXb/lucKzfL477BLX2u8U/fvVp9p5dlhDrGecM7Dfkgr6DhgX+Mbnd7o9mPrVj/bqSwoJ2HWJ7Zw6+8u93WsP++CjVD5/PK8jJGj7m6hVfLpAvUpBzUAjRb/AIjUbTPj7pjLPP/W3Ft1vXrZEC5WO9Yxx3y9Rhl19dv6f4cE6WECI5vat09xg2Ztx3C+Zs/fVnr9er1WqP9fNKSO0kRRa/LF+i3JtGo3t45ntCiO79Bggheg0478/DdAYOfCYN7O71eoUQ7z837f3npr3/46Y/LuhyfTZ75s/LvnY67OdddMU1d9wnAgqc8t02akB1Rfm9z89a9ulHB3dtN5iMyn1m7d7+/nPT8g7sNRhME/7xgFarFUJo/8yjGozyHpl0ee6+3UKI95+dNuelGR+u2hbgqSPwS3AAAe5Xgd/KavX6FV/O/+nLzwpysrr3G3DbY89Ir4mn5VF/rKd0pZN7pX77u3VGs+W4N0tgp6fFvfhw3hO3Xrvx55+69uk3ctx1+3dsnvPSkyu/XnjcCxqMRiHEj18t2PzzT1HtY3P27nz36X+/8vCdVeVHUzp3O5xz8P3npjntdSd0zu8/m/fxf54tKzly8XWTNVrtd/PnzH/zxT+vziCEmPPKjOw9Ozuf0cevmPjU9Iw+/aV/eoNBCKE3GKVntBl3TNq6bs2A4aOTO3Vd+smHM+64PvDon0GjLu3a+ywhRGJ6l8sn3xGX1MCLiuytJx5a9OFbGo3mgiuvzT+4/4V7b/7tx++Oc7sZTEIIe231C/fdptUZImM6HMo+8M5T/6ooLZHu7s/cfeO+bZs6n3Fm/6EjDx3c9+GLjy/77GPpsu8+8+jmtSu1Ov3wy6/evGblhtUr5N2exJH6yd67c/aTDxXl5SSld3a5nE/c9seMJ4PRpDxbfGr6oNFjhBDmEOvlk+/o+mcyJfv+s4+++eSD8pLibn36bf1l9QfPTxdCSD8UIYTRZBRCvPfMo7n7dyeldzl6pHDJx++tX7lMetBOv3n8xtUrwiOjhl42rraq4rsFc96c/uCfZRiEEN8tmLv6m0Ude/Qymsw/frlg9pMPHco+eOG4670e78evPjv3laeDP95W4/9emjH/zZc8HveIq65NSE1f+smHLz9w+3F/9AajWQiRf3DfvNefj4lLKC0u+HruOzMfvmvFovl9Bg6rqaxYPOedfds3n9A5nQ7781NvWrd8aUbf/pkjLtm5ft2L999eUnhIvttn7d4+95WnOyQkR0RHK4sxmszy41d+G6c36B11tY/fOmHN0q9SOmecPWzk7z99/+iNVxUdygtwXO06xF9+423S6RFXXTd0TKCJSyf3qAlwHxZCvPTAncsXznM6HMPHjDdZLBtXr3jilmul57dln879bsGc8pIjg0aPsddUf/H+LOVuT+LJpEGZIy8WQpQWF5QWFwghFn3w5pyXnyrKy84ccUlip4x92zbNuHNS1p4d0plnz3hkw6rl5hBr5vmj8/bv/WjmM0v/+6HfDpd89O7/s3ffUVFcbRyA313q0qug2BABURTFhgj23nv7EltijSW2aNTEGqOx9xI1xhJ7orF3EBREECsIiIA0kV6Wtu374+pmpYwrLizo7zkezro7O3Nndm6Zd+7cG+h9zdbJecqSNUTEke+KlNINmrZo26OvvKxwblW0+lSE7MyaUKumj7t++qiltU2vEWPEYtHfe7cd2fTrB79YHtk5JiJ0w7wpYY+COvYfWqueg//1S5sWzmDD0hUvjRUTY2JhIc/OhqZmRKSprUNEZcjO5X0KcVfH3FUSR3Yuw55yH/Aii5VWainf1mKyM9K2Lp5tWd3GwNAkKvTppgXTim8uJzNj2+LvQ4Lu1XFs6Ni0eUig37o5EyNDnnDvC3ch+WVC7i7io3K3yivrMufuMrb8VfHTvLdCzrJLEbsays/NObT516YeHWzq2iXFvdqxdF5yYnwdeydbp0ZSqTTo9turiSf37hBRyw5dv6hockU0pN/9XtuXzjE2NZOIRX5Xz+9cPn/Xsh+ate0oEYuCbt+4fOJQeTSky3DGVuaGdHR4yJ6VC5PiXjm5tqrX0Hnvqp8UV1uGvKlkjuMo4pQ/DRhlal4l2+eKWnXqTkTPH9yTDycdfNebiNy69OI4Mu/KB+GOn+dIZdIade2Ur6o4ri+4Cyifi2d3LJ2X+CqqbY++LTp09b34z6b53yXGRHH/UucO7rl++mhOVma73gOE2VlXjh/cs3IR+ygrI+3079tMLKr1HTNJ8SsyHo+IxKJC9l8dHV0iSop7xd1i7DxohDw2qvjT8IhHRGKx6O3adAVEJCrIT09+zfF7NWrZxqau3X9JerdCXT29hi3cWDSZiLzOnSYi69p1LaxtuAM+A8ZPZTdXmnl0HDB+Kl/zbYDl1J4t4U+C6zk5Z6amnD/0u8/Fs9zHkxs7Mf5ct6Kmnb1zyzZsnXevniciUWHB+nlTop4/s6hu496jz5HNq7PS0+RfLC2U16n/cHPrGizZ/cdO4S46uKvg0nCcVx9syoY/Dj60/hdhTlZebk7Q7eun9mxVVa7nKNKLH/CPrak/PZqssh7KL0OeSCWS5p6dpy1fT0Rtuvd9/uB+bfsPT5TE7pMU5OYt23tSIhbN6N8+OyNDKpbMW78nOyP9u95tc7MzoyOeOzRupvySMRGhDZq17DJopFuXXrXrO25ZODPgxuWxc5cQEZ+nQUQGRiarj5wrEuIkokHfTBv0zTQ2XM7z4PsGxiZ9v5rAbpKICvLbdOvDnqfbtXy+76WzQbevt+7Uo5Tdona9B71+FR32KKiWncOQCTM4jsCbhFi/q+eJaOYvm61q1ek8aOScIV3/3re9VcfuHN9ihVR+bi57VCE/N3d6v/Z5wuzQh4FunXuc3LVRJpN1Hfw/lmC7hk0OrFt2Zt+2TgOG52SkB3pfI6IZv2x0buk+cNx3s4d2JSKSycq2p0V4/XuSiOydmy7ecYjH4x3ZsvrS0QPy9cvZ1LVr12ug76WzAj0Ddnxev4pWXODmP8eJqO/oCcOnzJFKpUu/Hf4mPlZegPKIT0QW1WtMW7GRiFZNHxsS6P/0vn+L9t0uHfsjMzWltn2D5X+c0tDQ6Dx45IJRfQJuXo59EVarviOPr0FEWWlpa09cYqXtmf07iWjEtDmd+g8fMun72UO6XjlxsN+YScZm5kru8ufhxZNgIpq65Lda9R3Z76itoysVi+R1TInYfb6EqBcb/7lhXq16fq7wgc/NF08fbjx9Q6Cvv2jMoJjwkJCge/bOTZVfMvr5M8saNWvVd5yy5Dc+nx/+JDj+ZcQDX69uQ/7H0+Cxedi+X721RfuurEebPDGW1W3YU1QiUeHisYOJqP+YSfqGxl7nTiXFxphbVZ/561Y+n1/f2WXvqsWXjx6QPx5bnGV1mwHfTDtzYBcRdR/2tXXtukXOT0VlyzUc5/AjP59ngXc1NDVX/nHaxMJSJCqcO6xH6usEr3Onug39+taZE2zXhk6eJZVKl3w7LCr0KcsaZStMSiTvxJGRkqIr0Dv7524imrJ0LdupLYu+D7h5+d8Du2f+uiUk0D8k0F+gb7hi3wltXYFT81Z7Vi68eOQP+V16Ho8X+iDg2I715tWqz123mxW8HPmueCktFovuXD4nLys4JgwscbX9x042MjX72CNQdWWlpyXFxhgYmyzYsp+1Gq+d/sumjt0Hv1ge2Tns0QPHpi3sGzcbPmV2dkb6lJ5t4iLD46Ne1KxnX7w0VtSifVeWx5PiYxd+3Y+IRk2bR0R+1y9+bHZ2cm31iacQd43AXR1zV0kc2bkMe0pEHAdccTGOUkv5thZbVWJM1Ir9p2ydnHuOHD9nSNfXr6IjHj9weP8m8eUTB7My0p1bus/ftI+Idq/40efiP1dPHpyyZC3HvnAUkhzf+rxlZ6Qjdyv6qNyt8sq6zLm7bJW1Sn4axRVyl13vbZrHY6N/Dhg3pXWnHgPHf/fD8J5vEmLvXj3Xf8zkDn2GRoU+e3jXi/UUeRpwh4g8evTn2JfPUnk3pOW/V88R49y79bGuY/vXljUhgX4/7znq0LiZQF//8rE/nwcH9B8zSeUN6TKcsZW5Ic2uVR1cmi/afpCIFK9Vy5Y3lcxxHEWc8qcBW5UyNe8H2+fF2To2MreqnpqU+Pieb8sO3YTZmRGPHxBR2259OY6MBl+DBZTb9Ro4es5iIspMS1WmqhJmZ3JcX3AXUC+eBRNRv9ETuw39mohc2rRLT0nS1i0a21GUK8w5d2gPEc1as92hcbNeo76ZM6Rr0O3rr+NeWdesfWrP5tycrG9+XK4jeBtfk8lkPB6vXoNGj/x8bv17so5DA2F21n3vq0SUl5NdthajrVMjIop6/izQ+1rTth1P793yNm3Z2UmxH/17ye1f/fPNsyc0tXVad+4xbNIsIspISeYI+Az6ZtqTgLupbxKbeXRQHIzYrJrVnLU7iUhLe77vpbN3Lp/17FX2kpxFz109O30180ci2rls3p3L53wu/OPerU/Q7ZsZKcnaurrL9h7XNzR2cWu34Yep8lh5aaG8LoNH+t+4mPo6QZ5sjqKDowrmwHFefbApGxXyZM2xC9Vq1GIfPQ30U1Wu5yjS3zvg6qupVdNDuVqN2kT08I7X9iVzT+/dKhGLugweyT24jKImbTz5fL6Wtk71OnZE1LC5GxEZmpiaWVWXD0as/JLf/rhi8Y5D7GaauVUNIsoTChU31673oOLRZLmk+Ni9qxYR0fQVG9kANNHhoURUv1ETtoBdQxciCgsOLOvRek/U82dEpG9kbFWrDhFZ2dQyNDWLiwzPycxQ5uutOvVgd6hs6tYjImFmhjA7k93NaNnx7UUXe5GVkR4fFfHy+VMi0tLRdXJtTUTG5hYubu2IiHg8lexpTEQYETX16MjO6Q793j5hQR/TT0EkKoyLekFEzTw6sSZv+z6Di4/f37pzT/ainlNjIsrJTCeix/53iKh5u87sMdiatvXZPb1nQf7yL7q4e7IrnOyMdNYBs35DF7b+ek7ORBT2SDU/bhViaVOLiLb9NPvYjvU3zx53797XvXtfJe9Z1bZ3YvHHWvXsiciuYWM2wkxtOwf576L8kg4uzRfvODR33S7WkrC0Zln4vylrjc0tWCO4NEc2/xr/MsK+ievgiTOJKCYslIhsGzizFdZ3bkpEz1X3E39Krin5HL7nQ0QOTVxZ+aOlpd3UvR0RPQu8l5+by7KGS9sOLGt49hogzxqfWJiUJvRBgKggn6+h0bxdF/ZOq47diOhZ0D0ienr/LhHZN3ZhZ0u73oMO+z2XP3PNnkTe9ON0mUz29ewfWRtLmXzHXUqXqLTVhj8O+pTdr3L0DY30DI1zMjNWTR93cs/mR34+PUeMdXFvp+TXVZuduw353+Idh4ZPmc1qatZMV5yBWl4al0gkKtyycGZBXt6AsZMbtWxT3tn5E2uE4tUxd5XEnZ3LtqcfPODMB0st5VtldR0b2To5swKHlTysmaHoWaC/fCVENOmnXw/7PeeOJsuVWEh+sfQMDJG7y0z1lXVZc/enVNYq+WmKKLHsKlHj1h5EpKmpyfrEvQx5SkRte/TT1NZ5dNdHIpHk5+ZGPH1oZGLaxM1DmQP7OamYhjQRNW3bgYhq13dkvfvZ7b1ab5fMKI+GdDk1L+UqsiFNRKxToUubtyVnu96D3q6LxyvbniqZ4z5YxCl/GihT836wfV4i9+59iOixvy8RPbzjLZVKHVyam1hYKnNkOr8bXVPJhij39YVciQWUZY1aRHTmwK4/1604d/D32vUdO/QdwsI+pYl89qgwP19LR5dlGSubWof9nh/2e25ds3bcywivsyddPTsVv4fRffgYFuP6fmDnRaMHsiFlBPoGZWsx1m/kYt/ElQ0DONbTOej2LTZEksDAoGy/F2NVu665dQ1xYUFU6LMg35vy86G0gE9pWLyFiNhwCi+fP1Nm69xY/U5EjVt5EFFk6FMiehn6hIgcXZqz8UZcPTsZmpjIq8gPhvLkSis6uKtgDhzn1Qebsq279KxWoxYRuXXuSUTCrExV5foPFulFVHxNrZoeyvUaOo/8bu7f+7ezm1f/7Ntu69To6+8XOTRxLbroux9S8RfVfhc4YM8R6OrpK/5X8WaCMkv6XDx7ctfGtOTXpaXWwrrU4kYsFm9ZODM/V9h/3BR5BsjPFRLRoY2rFB99TUlKUPbocGIrF2ZlftXmvQ7dyYlxBsYmH/y6/AhoCwTspoQwO4u9Y2z+9jkm+Y0yYWZmvjCHiAQCgXzYQT1DIyKSSaUq2VN23gv03061x7KEfP3KriTjbeWk9249rG6Wyt5bSYm/fk5WBhEZm/73DJeRmXl8dGRO1n8TrVpUr8lesP0looWjByiuOeW1an7cKuTrmT/m5mSHPwqKj44kopO7NjZv1/XbH1eUsCiPVyT/aum8zZXsJFQ4J4vmX2WWzExN+XPDyoCbl0tLqmXpF6hsXt3rp48aGJvM/GXzu5vbQiIK9L6mmMVSEoo+J1Jmn5JrSjyHWQ2keH/byNSc3cmXVx7yrKGnbyjPGp9YmChiQ4YRkalltdjIMCIyMDaRj3nH0sPmWklPfsPCHKWt6s27B5avnz7GuhYqk+84SunSlLba1KTEj11VlaappfXd0rX7f1sSEujHhvK3qlm7x/CxXYeMKr4wr5yzc2TI4wPrlkeFFr3OkZOXxiU6vmN9THiIfRPXQe8e9CnX7PyJNULx6pi7SlImO3/snn7wgCvuKUeppXyrTM/AQP7awNA4iSg3J7vI5tKTk7hLCQ4cm/4CIXd/CpVX1p+Yu8tWWavkpylt7xTLrhLJd4dd/OcJs1mgx61zd99L/4YF388VZkklEo9eA7+08S4qrCHNBqaQ/5VfZ7Fn59mC5dSQVknzskQV2ZCWb05+rapvZMReyKTSsu3pR9W8HEWc8qeBcjXvB9rnJWrVofu5g78/vOP933gXnXtwnwMCvbeJqVbjbZmvZFXFrs1Lu76QK7GA6jpoZHxkhM+lM9dOHyGik3s2OTVr/d2KdUYmpT6SmPbmtWKWUfTH2mXaurrjf1hW/KMmrT1m/7bjxpljBXl5do1ctLS1z+zfYWZZrcwtxllrtv375+7osBC+hubIqXOWTBhORCYWVmX7vZjeo8b3HjU+0Pvatp9m/7VljZNrK+6AT2n0Dd/mBXa2F/khPqykKJ98nYYmZvJ1vk2e/n87q2donJ2RwX7cD4by5EorOrirYA4c59UHm7JGJqbsBTtRJRKxqnL9B4v0Iiq+plbZpHy9v/rWs8+gyGePwx4FeZ8/HRX67PzhvbN/28GqIsm7gZByc7I4ViKVyohIRm9LzHdFZwm/fWlLJifG714xn4h6jBjj2rZjXPSLg+tXFvkuX7PUKVxO7dkcEx7SsHnrwd9Ol7+pb2ickhjPVih/U+9d9fOJWDbTNzKe+ct7U6JXU2LuHUWsgJCRzMD47dksjyzLR6UxNDXLz89jd03ZcxxElJudJR975NP3lGWD3HebFma9fSGf9E8Z8jpe+K4gyxVmc4ykzkoHdgoYmZqmvk4QKpxmrC+V4jPv/HeZx8D47TD8k376Vf6MPxFZ1uC6CvosWdWq8/OuI5Ehj6PDQgO9rz65d8fr35OdBw6v49CQLSAf76l4k0VOxnLluwYPy5XsTeWXPLF7U8DNy1Y1a4+cNldP3+jojrVRoe/dIOWVPgVTevKbXSt+5PF48scL5CdwwxZuA8ZMVliLyi51VFI+vHcOm5gp5l82Vhp7nztrqKowIaIbZ44RUR17JzNLK5aePKFQIpGwdgkrUlgtxRooiqktQt/IePrKjZsXzHh6/27wHa9mbTsok+84SunSlLraj9/9qs7Fvd36k1fDHwVFhjzxvfJv/MuIU79v7jhgGCvzJeJC+ZLC7PLNzjuWzE2Ke9W4ddteo8Zr8DXWzPpW8v6oiPzSc+KTgDuXj/1pZGYuv6Yt7+ysqhpBXh1zV0nc2blse/rBA84oX2p9sFWWm/NfFwk2aXjx1ra+gVEKxQs5m38fpFhIfsmQu8tM9ZV1WXO3SirrT/lpSl+nVDG/F5crzGFXqsLMTMVwQId+Q30v/Rt816uwIJ+I2vcdrPyOfDYquiEtkxIRTyZ7f0lpeTSkVdi8LFFFNqS5r1XLtqdK5jjli7gPngbK1LwfbJ+XyNbJmY168Sri+aO7t4moVcce3OdAdvrbrtNssCOmtKpK8bvc1xclHZb/Cigdgd6kn1cPGDclKjz0sb+P76UzzwLv+l4622vkuNJ2Td/QkB06eQyEEYvFYQ8DiWha3/dmX/za3Wnk9B96jxrv6tnJ1bMTe5ONzGDn3LTMLUYjEzM2BAQbzVwqkdRzaqypqVmG3ys9+c2zQL+C/PzOA4ez4aRq12/wMvRJxJNg9nhQaQGf0vwXO8pIZ0Fe7gQoE+UT/pfRMuTr1GX1SNZ/y7NAM5/PVyaUJ1da0fGxoSQ5jvNK+aYsO1FZ4aySXP/BIr2Iiq+pVTPkRfiT4EObVsW9CG/WtsOIqXMWbfuTjR1BRPpGJmwwFIlEQkQP795++53yuXedFBfDTsf/zVjQsIUbK3A/eDuCCX0QcP7Q70Zm5tNWbuQr5De7Ro2JKCM1hQ18LpVJX8fHaGvrcq5MWfUaNmGZ3NjCsmELNweX5lHhIVkZ6XoGZQxY6+kbNGjWkoju3bjE3vG/foGIzK2q29jWZ+OQiEWiZ4F+7I7H8+CAT9xT/+sXT+/d+sjPh4jY4x6P/H1YNrjvVfr8OTweERUW5hf/RFdPjz02+NjPh92KDPS+oeTuu7RpT0SB3lfZPa7YF2FvH3loXcIUvQJ9wxp16rFHL9kup75JTHnzWudDMwt/Zgrz8y4dO/DnuhV2DZt0Hjh8/qZ97PGipPg4Pp/PiiH2cEpOVmbE02Aqt/xLRK9fRbExfVq071avYZOkuDgle6XJZLJtP8/Ozc4c+M138scL2ONFRJT6OqG+s0vDFm5m1azjol8Un2C6zFRePjR1b09EocGB7GZ1YX5ekPdNImri5qGrp1e9jq08a0gkkkDv/2YQVlVhcunogTuXzxFR39ETicjJtaWunp6oID/Y9+1A/n7XLsifFqzj2JCIIp48ZI8jPb1/96s2Dab2biv/yWxs6zu3dO83ZhIRHd60SiKRlFO+K221uoIvKzsnJ8Sd3rv15tnjDVu49R09Yc2Rc4YmJsKszLycbH0jY9ZMTE6II6KIpw9ZA66cupJJpVI2b0m/MZMbt2qrqaX1ttGpxAMrWelpO5bM4fF4M1dtll/Tlnd2Lo8zk6NK4s7OZdhT5Q+4CkutVy+eJ0S/JKKE6JfscYT67wZ5lGOlBBuvjYhO7d70VZsGWxd/X6T9AB+UnBiP3F1mKq+sy5y7Vd7yV/QpP42iEvPmvesXWfzl6X0/+U9GRA2atrSobvPwrvfTgLt1HRspzh/1hfi8G9LlesZWcEOaiOo6NmTXqmzhewr9/sqwp8rnOBUWccrXvBzt89K06daHiE7u2ZwnzG7Uwp2V0h91ZDgaooqLcV9fcPO/fnHnsnn6RsZunXtMXPTLV98vVHwmskR1WQyksCD0QQALuo3v2PSrNg3ioyPlc1E2aNbS/t3j9Q2atTSvZn1sx/qpvdv+s287G7r6kd9tPQOjxq3alq3FmBQfO29Ez+/6eLARUa6cOERErTr3KNvvlZactGv5/ANrl76KeM7mo0qIiSQiI1ML7oBPae57vZ1/8rHfbSKyd27CvbwyUT75nJaP/P9bJ8uDL54Fs86zIUH3st89ns4dymNNGlFBAftvaUUHdxXMgeO84mjKclBJruco0iNDHp/eu/XGP+/NHlHxNbVqGmopCXFXjh+8f/Nqm269NbW12R2ths1aERGbczkpNmbd7IkWNWziXr5QyRZLU6OuHSvcd6+Yb2pp9fS+n5mldVry67+2rOk3djL3d3ctn88GWtqycCZ7R1tH54eNe7sPG33rzAn/axekEolljZo3/j6anytcvu+UShJsZmnl3r3v3SvnfvludKd+Q8OfPgoJ9Gvm0dGtS88yr3PY5Fkrp3595fjBN/Gxunr6/tcuENHIafP4fL6pZbUmbh6P/X23LJrl3q3Xg9u3+ArndNn2NODmlYBbV3qOHOvSxrNd78E3/j4W8fjBqmljjM3MQwL9S/uWmaUVe3Zm/29LGrq61XVwUvzUs8+gY9vWnv1zd+qb1wnRL1MS45Tc9x7Dx9w+93dU6LOfxw+t79zE79pFNtcqG/KphOVHjtm/esmB35bFRb7IzxXevvC3oamZW6ePnsSsStPQ0vY6ezI+OjIzLaWGrV1WasojP29NLS2HJs2IqIlb23s3Lh/csDLxVdR9r2tWNWplpaWWX2Js6tUPexTk9e8piVQS/jjYvrHLo7u3g25fYyNncfA+d4rdYX4W6B/ybvitTgOGt+zYzbJGzaS4Vyumfu3Spt3dy+feJMSOnP5Dkckrykzl5UPDFm4u7u0e3b398/ihLTt0fRzgm56SVNPOwaPnACLy7DnwxK4NZ//cnfYmKS76BXsAh/mUwuRNYtzKqV+zAwN76gAAIABJREFUjjOsXeLWpSf7okDfcMD4745tW7tj6by23fslxLwMexioq6c38JvpRNS6Y7dLR/+IfRH28zdDHF1a+F7+l4j+N32+PIrBKryeI8deOXkoKe7V1ROHeo4cW075DtmZOX/wdw0tzdgX4cbmFglRkdkZGTXtHAxNTAX6BqYWVukpSWtmfduyQ7eAW1eq2dTibn9/Cj6fX6NOvYSYl6f2bHZybRV466qTa6vQBwGXjx/U0v3AheJfW1dnZ2QI9AxO7v6vL8y4H5a26NC1XLOzyk8h7iqJIzuXYU+VP+CqKbVkxJ4oWjZppFuXnkG3bxBRbfsG8parXK+RY+/fvBL6IGDV9HF6+gaB3td0BIJB304v0n74uK1/qZC7y0zllXWZc3d5tPzlPuWnUVQ8b/J4vOM7N7x49vj1q6g3CbGa2jpsbh+mU//hJ3ZtIKL/zVzw6XtR5XzeDWn3bn3K74xVQ0O618BbZ05EPH7wy3ejjc3Mnz/8bzzTMuRN5XOcaoo4pWveD7bPS9OqQ/fzh34P9r1FRK07dy/bkSmtqhIqDEHJfX3BLSTQ/87lcwnRL5u0aScuLLx75TybppXjKxbWNh36DfX69+TmhTPadO0d6H29MD+/Q7+hdeo7srkomayMtKk93Ylo0faDPB5PS1vn/KHf/9637WmgX+yLcIlY3HHAME0tLe4WI7ukyslIJ6LUpNfsvwPGTXFu6a4r0EuMiVo8eqBA3yAmIlTPwMi9W2/u38vr3CnfS2flwdazB3bd+vekWTXrqUvXOrg0D38UtHD0gJq29eOjI2UyWfU6tq4eHbR1dDkCPsWxft8P797+dfp4XT29oNvXiahj/6EcX1EyyvfY3+fX6eNNLS1YXyW2TlePTgbGJjmZGT+NH9qweWv/65f1jYzZucEdyjOxqEZEN/4+lpGa3Hf0JI6ig6MK5sBxXnE0ZTmoJNdzFOnpKW/+2bfdtkEj1ktdXTW1anoou3fv+7+ZC6Qy6YUj+87+sVMiEX89a+GoGT+wWQL+N3OBrp5edPgznoxmrdnGvlKYX0LX1E9nZmk1eMKMWvUdH/h4pb15PWvNtqGTZxmbW/he+Zf17ubAavfUpMTnwfff/nsYSEQ2de1mrdlu17BJwM3LFw7vtW3QaMGW/fUaOqsqzWPnLek4YJi4UHTmwK7osJDeX307+efVn7JChyaui7b/Wdu+QbDvLb+r56vZ1Pp+9TY2tDkRTVz0q62Tc252pte/p1p27Nama28iEhcWqmRP7Ro2HjPnZ01tndAHAVFhIeMXvB2NSKPYHMfWteuyW6A3/zkeFxlW5NNeI8exSRJ8L53VMzDsO2aS4igzHAyMjJf8/pdLG8+Y8JDrp4/KZDT42+lj5vxc2vKd+g8f+d1cc+saV08eunv1XJtufZbs+kvJOTQ+GxoaGrPWbG/ernPArStn9u/wufxv83Zdlu07wYL+o6b/4ODSPD8393lw4Iipsxu1cCMiUfnkXyLq/b9vG7ZwyxXmPPK73bpTj2nLNzZx84gKfRYT8Zz7i5nvhnYJexgoz8JpSYlaWtpz1+9u2rbDq4jnZ/bv4GtqjJu3VJk5c5VUHuXD96u3dR38P2FO5tVTh1MS49269l684xBrvvT+6hvPXgOJyOfSGSMTUzYHiFj09jnKMhcmhfn57IgJs7PcuvSauHjVZIV5Bvr875vRc37SEejdOnsi7GGgg0vzpXtPWNnUYg8HLd5x0K1Lz6S4V17/njQxtxi/YFnbHv2KrF9TS2vE1DlEdHrv1pzMjHLKd8jO7Gm7WWt3WNWse+vsiTP7d4Q/edD7q29/3Lyf/QqTf15tUd0mNel13MuI71dtMbWoRkQfrBzLbMS0efUbucSEh0Y+fTRu/tJR03+wqWcf5HMjIyWZ+4uZaalElJeb8191HHw/P1dY3tlZ5acQd5XEkZ3LtqdKHnCVlFpiUSER2Tdu1nvUNzf/OZ6RklzH3mnW6m3Fl6xZz/7nPX/Vb+QSEugX6H3NrmGTeRv2fIF9GD+dZXUb5O4yU3llXebcXR4tf0Vl/mm4yWSyqcvW3fe6FvYoyNDUbPZv200tq8k/dW3XiV3Kunfrq4qdqGI+74Z0eZ+xFdyQdmjcbPScxexaNSbi+fSVG9lXRIUFZdtTJXOcSoo45WteJdvnxdVr6GxuVZ3Fylt1/O+GuvJHhqMhWgTH9QW3kdPndxvyVXx05Nk/dl44sq963Xozf91SfEq9Ir5ZsLz/uCkSsfj66b8KcnO7Dx89dm6pIQKmebvOA7/5zraBc9TzpwIDg+7DR7PLGe4WI8s77JkVUcHbKyx2Pkxe8lvj1m0lUklibJStk/PC7QfMLK25f6+U1wlsDQV5eUSUEPPyefD9yJDHRDT7tx0ePfvp6unHRb3Q1NRq1anHj1sPsAHWOQI+xbHzatwPyzLTU4JuX9fU0ho6eRab+YaDMlG+EVPnZGWk+l76V3Gdunp6s9ZsMza3eP0q2v/65a+/X8gG4BaLCrhDeb1GjBXoGSTEvLx89E8e8TiKDu4quDQc51XZmrIqyfUfVaSrpabmldiRflvkYwnJWptaqXBL8CVIToxPjo8VGBqyRy2C73itnzvZqmbt9SdLH/uiJDERocLMTIsaNmy6zKPb1l44sq993yETFpY6jI66XEl65WJiMaD6B277V6RIYeav4UHf1mmo7oQAVDFHYsPH13VqZmypxLIV5NqbV14p8X2tbdWdEICq7Z/Elz2t6nSw4JqNqoIFpCcdiwsfZmOv7oQAcHn9Knru8B5EdMDnaWnP6p79c9fJXZva9uirOOu9km68eWVvaFqpMkJ0btay5wGT6qqs8xAAwBdlet/26SlJ8zfva9yqrbrT8kUo75raP/21Np8/1baEgVBUNjbZF+jAumWKg+IrGjb5ewvOKXQ/KC056dj2dSV+pKsrGL9g+aes/GNdPXX4xdNHJX7Utns/xSdV094krpo+lg37bWxucf30X0TU5l3naOU9vOt9ctcmgb5hp4HDRQUFV08e4vP5rTp84EYZgPKe3r97+8I/JX5k26DRp/eKKtfy4aOU954CqJ3ylVQZVNHqGODzUN7nPCrrT3Ri54awR0Fhj4I0tXWGTPzAgJLwOUFDupLnzRJ93q2IynPOfB4+v7Plc8rLH6Vca2r0UAYVu33hb+9zp5PiX2WkJNe0rd950KiuQ0Z97EpkMtmRLatfPHkYF/UiP1fo2LTFkIkznZq1LJ8kfxL0UAb4bKCHMsDnCj2UAcqGu9/TxvnfBd2+Ydug0bAps8vWEw09lAEAPjPooVzByrumRg9lqDjteg9iwx9/Ch6P99XMH1WUIgAAAAAA+GjWtese9it1+N1Za7ZXbHIAAKCy23rOW91J+LKosaZWzaR8AAAAAAAAAAAAAPDZQ0AZAAAAAAAAAAAAAJSCgDIAAAAAAAAAAAAAKAUBZQAAAAAAAAAAAABQCgLKAAAAAAAAAAAAAKAUBJQBAAAAAAAAAAAAQCkIKAMAAAAAAAAAAACAUhBQBgAAAAAAAAAAAAClIKAMAAAAAAAAAAAAAEpBQBkAAAAAAAAAAAAAlFJyQNlES0cTsWYAJehqaOppaKo7Fe/R4vEstAXqTgVA1WOipa3Fq1x1nw5fo7KVMABVkYGGpi5fQ92peI8mj2+oqa3uVAComY6Gpr6GlrpT8R5NHt9KW0/dqQAAAKgUNHl8E02dEj8q+crZWlcvLj+7nFMF8DmIys200TVQdyreU1vP6ElmikQmU3dCAKqYJ1mp9fSN1Z2K99TRM4rIyVR3KgCqvLCcjDp6hupOxXvq6RuFZKepOxUAahadm11TULka0jUFBs9z0gulEnUnBAAAQP1ic7Or6+qX+FHJAWVXk2o5YlE5pwqgyiuUSjR5fCcjM3UnpKj2FjWihFnqTgVAVRKfL2xmYlnZugPX0TO00BFkoUYG+ATponwbgUFpTWF1MdHScTI0TSrIU3dCANRGIpNJSeZsZK7uhBTV3qJGVC46VwEAAFCORORqWq3Ej0oOKJtp6wysYXc8PqKcEwZQtf0VFzHF1rlyPSFPREQ/ODQ/9zoqU1So7oQAVA15EvE/8ZHz7F3VnZASzLRzOR4Xru5UAFRVUpKdjI+cVb+puhNSgtn1m/2dEFkolao7IQDqcSQubGJdZw0eT90JKWpW/WZXkmJSCvPVnRAAAAB1OhYXMdTG3riUUdp4stKfi/dNTTzwKrSxoVl1gb5OJRt4DkCNciXiNwV5Xslxqxu5Oxqaqjs5JRNKxBMe3GhjZm2oqW2hLZAQrlcBitLg8dIKCzLFhV7JcftcO5tolTw4lNrF5eVMCL7Z06qOmbauoYYWVbpLb4BKh0+8THFhWmH+5aSY/a5drHUr6YioqYX54x9c72xZy0RLx1RLV4rKGr4AuRLJmwLh7ZSE5U5ujSrfc35MvlQy4cHNVqbVDDS1LXQEUhnyJgAAfCnyJZLEfOHDrJSJdZzdza1LW4wroExEMbnZ519Hv84XJhXklk86QVlSmSwlOblatZK7mkNFMtXWcdQ3HV7LvrLNIlLcyfgXT7NSRVJpSiEeqq0UhEKhVCY1NKhcQ3l+sYy1dHT4Gg2NzEbVdFB3Wj5ARnTw1fPQ7LQcsQgDO1YqMqKkpCRrKyt1JwTeI9DQ1NPQbGho9nXtBupOy4cdiQ0LyU7Lk4gx4lwFS05ONjM31+BXwofNPmem2jr2BqbDbOobVfp5KU/Hv3iSlSqSypILcS0MUNFS01KNjIy0NCv7FTfA56earl4NHf1+NWxrck4Y9oGAMlQeOTk5/fv3v3HjhroTAgBld/DgwaysrGnTpqk7IQCgGhKJxMPDw8/PT90JAYCP1qtXr4MHD1pYWKg7IQAAUNSYMWMWLFjg5OSk7oQAQMlwQx4AAAAAAAAAAAAAlIKAMgAAAAAAAAAAAAAoBQFlAAAAAAAAAAAAAFAKAsoAAAAAAAAAAAAAoBQElAEAAAAAAAAAAABAKQgoAwAAAAAAAAAAAIBSEFAGAAAAAAAAAAAAAKUgoAwAAAAAAAAAAAAASkFAGQAAAAAAAAAAAACUgoAyAAAAAAAAAAAAACgFAWUAAAAAAAAAAAAAUAoCygAAAAAAAAAAAACgFASUAQAAAAAAAAAAAEApCCgDAAAAAAAAAAAAgFIQUAYAAAAAAAAAAAAApSCgDAAAAAAAAAAAAABKQUAZAAAAAAAAAAAAAJSCgDIAAAAAAAAAAAAAKAUBZQAAAAAAAAAAAABQCgLKAAAAAAAAAAAAAKAUBJQBAAAAAAAAAAAAQCkIKAMAAAAAAAAAAACAUjTVnQD4CCKR6MyZM5aWlubm5uyvulMEAB/t5cuXOTk5BgYG6k4IAKhAaGioVCpVdyoAQFnp6enJyckpKSnJyckFBQXqTg4AAABAlYSAcpVhYGCwZs2aW7duJScnp6amJicnp6enW1hYWFhYWFpaWrwjf21mZqbuJANAUaNHj3716lX//v3t7Ow8PDw8PDzq1aun7kQBwMeRSqU+Pj537tzx8fGpVq3a7t271Z0iAPhPZmamPGTM2szsdUpKSkpKiqGhIWstW1paLl261MLCQt3pBQAAAKh6eDKZTN1pgDKSSqWsZSxvIiu+zszMlPdlZo1mxdcmJibqTj7AF+3hw4e+vr6+vr4FBQUssty6dWt1JwoAuLx+/ZoFkf39/T09Pdu2bevp6YmnhQAqXk5OjmKYuEj4WCAQyFu8RTpeWFhYaGqiPw0AQBUwZsyYBQsWODk5qTshAFAyBJQ/WxKJpEi/DPaa/c3Ozi7Sr1k+jAbCzQAVKT4+nkWWHzx4IA9RIQ8CVB5Pnz5l/ZGzsrJYDnV3d1d3ogA+c7m5uSUGi1m3CU1NTcUn84p0ntDW1lZ38gEA4FMhoAxQySGg/IUSi8UpCor0cRYKhUUCzYqvjY2N1Z18gM+QSCSSP0Rfq1Yt1m3Z3t5e3ekC+BKJRCJfX1+WH21sbNjNHgcHB3WnC+DzkZ+fr9gKLdINQiaTldbL2NLSUldXV93JBwCA8oWAMkAlh4AylEAkEsmb+MX7OOfl5SkGmouM3WxkZKTu5ANUeegRCaAWCQkJ7ImBoKAgdlMHTwwAlJlIJCoyfrFi+FgkEhXpsqDYiUFfX1/dyQcAAHVCQBmgkkNAGT5aYWFhkQcPFS8VCgoKShxMg702MDBQd/IBqpLiY7Z6eHhgBiEA1Xr06BGLI+fl5bE4spubm7oTBVAFsAHWFFuDih0RhEJhif2L2V9DQ0N1Jx8AACovBJQBKjkElEHFCgoKSru0SElJ4eiNYmFhgXAzQGmkUinrs+zr62tpacmCy2hgAZRZfn6+7zu2trYsjmxnZ6fudAFUOkXCxIp/2RTQxYPFmJMDAAA+EQLKAJUcAspQoRTHyyvex1kikRQZQEPxsgQPPwIwoaGhLAqWkpLi8Q6Px1N3ugCqgLi4OF9fXx8fnydPnsizDwZrgi9cWlpa8XixvJ0mb4wVnwTPzMxM3WkHAIDPEwLKAJUcAspQieTl5ZU4SSC7pGHTsxSfJJDFnfX09NSdfICKlpKS4uPjw4LLbDSMtm3bWllZqTtdAJVOcHAwyylisZgFkVu2bKnuRAFUnIyMDI6OxiYmJsVnwJM3sdSddgAA+BIhoAxQySGgDFVGbm5uiZMEsrgzj8crbexmCwsLgUCg7uQDlC8WLLtz546JiQkLLjs7O6s7UQDqlJubywaK8fHxcXBw8PT09PDwqFu3rrrTBVAusrOzSwwWs2aSvr5+8fvx8r98Pl/dyQcAAHgPAsoAlRwCyvCZEAqFHGM3a2holDiYBnuhq6ur7uQDqExYWBgbajkxMVH+RL+Ghoa60wVQQaKjo1kQ+fnz52y0cU9PTwyaBJ8BeVOnxHHDtLS0OHoZa2lpqTv5AAAAHwEBZYBKDgFl+CLk5OQUCTQr9nTW0tIq3q9Z/lpHR0fdyQcoi9TUVPmcY61bt2aRNWtra3WnC6Bc3L9/n53tGhoaLIjs6uqq7kQBfBzFqSaK/5U/jFXi2F+4Ow4AAJ8TBJQBKjkElAEoJyeneJcf+WsdHZ3Sxm62tLRElx+oEu7evctibUZGRqzPMgbEgM9AVlaW/K5J48aN2aAWNWvWVHe6AEolEok4BqYQiUQcA1NguggAAPhyIKAMUMkhoAzwAVlZWaWN3ZycnKyvr88xmIampqa6kw/wnvDwcDbUclxcHIsse3p64kSFqiUyMpIFkaOiouTjuqB7JlQSEomktDG4kpOThUJhaQNTWFpaGhgYqDv5AAAAlQICygCVHALKAJ8kIyOjxFGbGQMDA3knI8XnUtl1I4a1BTXKyMjw8fHx9fX18fFp0aIFC8nVqFFD3ekCKNW9e/fYJHu6urrsjHVxcVF3ouALxTEwRWZmZvF7zPJmgImJibrTDgAAUAUgoAxQySGgDFCOMjIyinRTUnxtbGzMMZgGj8dTd/LhS8HidL6+vnp6eh4eHm3btkWcDioJdueDTbLn6urKhgK3sbFRd7rg85eWllZkPArF1/Jau3gvYzMzM3WnHQAAoMpDQBmgkkNAGUBt2MVqaYNpmJmZlRhoZq/VnXb4PL148eLOnTu+vr7R0dHykQQwLyVUvIiICBZEjo2NZUFkT09PjFkPqpWZmVli/at407fEIa1QCwMAAJQ3BJQBKjkElAEqqRIDzfIXRQLNRUbVUHfaocrLzMyUz3Xm4uLCIsuY6wzKm5+fHzvrDAwM2FnXuHFjdScKqjDFSXcV/7LKVCAQFB/IGMNSAQAAqFGzZs2IiM/ny2QyHo8nk8lkMlnbtm23bdum7qQBwHsQUAaokkqc6oe9Tk1N5RhJA4/iwscKCAhgMT4tLS3WV5S18wBUIj09nY244uvr27JlS09PTw8PD2tra3WnC6qGvLy8EkPGrJbU1NQs0rNYsVrU1tZWd/IBAADgPVOmTLl37x6fz5e/Y2ZmtmHDBmdnZ7WmCwCKQkAZ4HMjk8k4RtLIyMgo7RleCwsLU1NTdScfKq+oqCg2mm1ERISHh4enp6enp6eurm7xJd3d3UeOHDl9+nR1JBMqi9TU1EmTJuXl5V24cKH4p2FhYWxQi4SEBBZE9vDw0NTUVENCoXIrKCjgGJhCKpUW72Us/1tiAQUAAACVlq+v788//5yVlcX+K5PJunTpsmbNGnWnCwCKQkAZ4MsilUpLnGWIXaVnZ2cXCTQrDqaBuemBycnJ8fX19fHx8fHxcXZ2ZqHA2rVryxdwdXXV19fv3bv3ggUL1JlQUJ+oqKi5c+fGxMRoaWn5+fnJ32dB5Dt37piYmLCRkRs1aqTWlIL6icXi4hPfyf8WFBSU2L+YvdbX11d38gEAAECVpkyZEhAQwOaoNzc3X7duHcZAA6iEEFAGgP+IxeIUBUWu8IVCYZFnhxWv6o2MjNSdfFCDoKAgNl4Bn89nkeXFixe/efOGiHR0dDp16rRixQp1pxEq2rNnzxYtWhQXF8duYl29elU+JHebNm3YwClWVlbqTiZUHPboTGljGefk5FgoKBI+RuUCAADwRblz585PP/3EOil36NBh3bp16k4RAJQAAWUAUJZIJCrSfUzx6eP8/PwSA83staGhobqTD+UrOjr6zp07vr6+/v7+8smsNDQ02rVrt3btWnWnDirOvXv3Vq1aFR8fL3+Hz+cPGDCA3W9QHBEPPjPyeqHEIf45BqbA4y8AAACgaMKECcHBwebm5uvXr8foyQCVEwLKAKAahYWFJQaa2WuRSFTaVIEWFhYGBgbqTj6oTPPmzdkTagyfz2/duvXWrVvVmiioIN7e3ps2bYqNjVV808jI6ObNm+pLFKhMRkZGaTPgJScnK5bw8u7G8jfVnXYAAACoMry9vRcuXOju7o6OKQCVFgLKAFAR8vPzi4zXrDiYhkQiKTI9oOLrz3uIzBPxEY8zUyUyaXJBnrrTogKxsbFisZi9ltcuPB4JdAXW1tZqTBhUjJhXr6QSyX8/PRE7E+rZ2qozWapjIzA01tLqYGHjalJN3WkpF1lZWcWDxXIGBgZFbg0q/lW8kwQAAJXQ5aSYoIxksUwSm5uj7rQAfEDi60QzUzMdHR11JwSAi0BTU8DXbGhoPqZOgy+tKYyAMgCoX15eXomjNrMXMpmsxEAzey0QCNSd/DISSsTjg657WtQw0tQ219aRSD+H0vi3336TSqUCgUBDQ0MgELDfyNraul69eupOGlSE+Pj4zMzMpDdJyW+SMzMzpVKpSCQS5grn/zBf3UlTDRmPF5+X8yov29XEcpiNvbqTUxY5OTnFb+/J/+ro6JQYLGZBZE1NTXUnHwAAymjuE19rXT0TLR0rHT0EAQAAVILP42eJC9MK8y8kRe9t1tlG8Dl3hisCAWUAqOxyc3NLDDSz1xoaGhyDaejq6qo7+SWTEo0IuDShrrOhppa606Jijx49srCwqFatmpbW57Zr8LEyMjJYyNLNzU3daVGxc6+jGhiYfl27gboTUoL8/HyOgSk0NDQ4pldFPyAAgM/S4hD/ajqCVqaYERcAoLzsiX663MmtpuBLGc8TAWUAqNqK97ZT7HOnpaUlD50UDzqrMXSyNvxBDYG+nb6xuhIAAJ/o38SoUbUcnY3MKn7TpY1ZzwpDsVhcJGSs+LfqPtUBAABlczbxZUR2hodFDXUnBADgc5YhLryZHPdbI3d1J6SC4NFFAKjaDAwMDAwM6tatW+KnOTk5imGXhISEx48fy0Mw8oe7SxxMQ1UdbPv06TNmzJihQ4cqvumVEr/QsYVK1g8AamGspR2U8UYxoBwcHLxp06Y3b95cunTpE1cukUiKP5kh/5uXl1fk9li9evXk72CaUwAAUOSbmtjUGJOjAgCULxNN7YS8nMR8YXXdL2LgCwSUAeBzxsLNtqVMCCaffop59erVgwcP5OEbfX19jqkClR9LND4+fsuWLd7e3tOnT3d0dCSimLzsxsbmGpjACqAqs9HVf/NuLk2JRLJx48Zr164lJycbGyv75EFp098lJydnZmYW6VnctGlT+WvlNwEAACCTyb6Q6AYAgHo5GphEC7O+kCIXAWUA+HIZGRkZGRnZ2dmV+GlGRobiYBrR0dGBgYHyiI+BgYG8b2DxwTQ0NDTk6+HxeHl5eXfv3o2Pj+/du/e3334rlkpTCvMrcEcBoBzw6E1hHhHduHFj586d0dHRRMTn8/Pz/8vdaWlpxaPG8kEqigxM4ezsLH/HzEwNI2kAAMBn6WVuNnoxAABUgByJuEAmVXcqKggCygAAJTMxMTExMalfv36Jn2ZkZCgOpvHy5cuAgAD5YBrGxsYsuPzw4UM+n8/CTLGxsX/88YeXl9fQ6VNIu8L3BwBUTSwWz58/39/fXygUyt8sLCwcN24cu/PEigJ51LhBgwaKDzqoNe0AAAAAAABlhIAyAEBZsHCzvb19iZ+ybompqalPnz5VfL+goODZs2cJmzfXmze5olIKAOUl5FlIyq1bYrGY3TdiZDLZ3LlzWchY8WEFAAAAAACAzwMCygAAqmdmZsaeWNfR0ZG/KZVKraysrK2tW/fvHajW5AGASjRwauA6Y4aXl1dCQkJiYiILH8tkskaNGqk7aQAAAAAAAOUFAWUAgHJUWFgolUpNTExMTU3bt2/fvXt3R0fHSGFmYHiQupMGAJ9KW1v7q6+++uqrrx48eHD9+vXAwMCEhITc3Fx1pwsAAAAAAKAcIaAMAFCOtLW1u3fv3qtXLw8PDx4PE6IAfJ5cXV1dXV3z8vK8vLzOnTun7uQAAAAAAACUIwSUAQDK0YULF9SdBACoIAKBoGfPnj179lR3QgAAAAAAAMoRX4llAAAAAAAAAAAAAAAQUAYAAAAAAAAAAAAA5SCgDAAAAAAAAAAAAABKQUAZAAAAAAAAAAAAAJSCgDIAAAAAAAAAAAAAKEVT3QkAAIDP1s2zx/eDiqoPAAAgAElEQVSvXmLfxHXJ7r/KdUPJCXGzBnchon03H+gI9Kb3bZ+ekjR/877GrdqW63arit3LF/hcOtNr1PhR038o2xrEYvHJXRsf3vF6kxhvYm7RskO34quKCnv209jBRNR/3JShE2cSUUZK8pkDO5/c801Lel3Dtn6rTt36j5lMRAfWLbt++miRr9eoU++3YxeJ6O7V81dPHHoVGaZnYGjbwPmrGQusatXh3hARnTv4u9e5k6lvkmzq1Bs5fZ5zS3ciSn2TOLN/xyIbGjF1Tp+vJyi+s27OpId3vYno0N1QHo9XtkMEAAAAavT6VfTc4T2I6IDPU03N8g10fD+oc0pi/Oy1O109Om5fMtfv6vl+oycOmzK7XDdaVXifP/37L4tsnZxX7D9V5pXcvvD3zX+Ov4oME+gbODR2HT9/maGJqeICBXm5swZ1zspId2za4qedh1lj9dJffwTcuhz78oWZZTVHlxZfz16kp2/gf/3Stp9mFd/E9vO+xuYWUWHPTuzYEB0RKi4orG3v2G/MZJc2ntwbIqLH93yPb1+f8CrK1Nyy04Bh8oblnKHdkuJeKX7dxb3dvPV7FN9RSbNzx9J5d6+cU+FZx33VVvmvrSrsqhMUIaAMAADlxcTMskGzljXr2Vfwdu0bN83KSNM3MFbtamcO6Ojg0vy7ZetUu9oq4dDGlTf+PkZENnXt4qMjL/6136yaVY/hYxSXOfDbMsX/ikWiNbO+jX0RxuPxzKyqx4SHxISH6Ar0ug8bXeImNLW1iSg0+P6OJXOJyMSimjAzI9j3VtzLiNWH/9UR6JW2IRZNPr5zPZ/Pr17XLiYi9Lfvv/15z9H6jVzyc3OJSEtL287ZRb6wmVV1xe8+vufLmvUAAABQdWnp6jRo1pKIKvjesE1duwbNWlrUsFHtancsnRcaFLD13JfYRPG/cXnPyoVEZFmjZnpK8n2vq1KpdNaabYrL/L1/R1ZGuuI7hzf9wvorWNWqkxQb8yY+Nk+Y8/3qraVtRUNLKysjbe3332ZlpGtq6+gbGoY9Clo/b/KyfSdsHRtxbCj8UdC62ROlUqlNXbvXcTHHdqzna2r2GjmOiPJyhURk17CJlo4OW7iWnaPid6tos7Ocrq1USF1XnV84BJQBAKC8uHp2cvXsVPHbnbFqs8rXGf74QWpSospXWyUU5OV6nztNRFOXrnXv3jfQ+9qmBdP/2b+jy+D/yXsA+V46GxnyWFNLSywSsQu5JwF3Yl+ECfQMVvz5t5VNrcObf71y/OD1v492HzZ67NwlY+cuka//7J+7Tu7a1HnACCK6cvwgEbXs0O275euF2Vk//q9PckJcoPf1tj36lbYhsVh87vBeIpqzbrdLG8/jO9efO/j7xSP7Z6zanJuTTUTm1Wss3nGoxF0Ti8WHNv7C19CQSiQVfwkKAAAAqmJerXpp1X25GjBuyoBxU1S7TrFI9MDnpkDPQLWrrSqunTxERB0HDBv/w7LkxLjFYwYH3b4eFfZMHud9kxB76egfiq3BPGH2zTMniGj6L5tad+rBGquB3tcyUpLduvR069JTvvKXIU9//maIW5eeBkbGV04czMpIN7eusfKP07p6ehvmTX0ScOfmP8e/WbC8tA0R0fkj+6RSad/RE4ZPmfPIz2ft7AnnDv3efdhoDQ2N3JwcIpq5equZpVXx/aq6zc7yuLZSLXVddX7hEFAGAKgCCgvyrxw/dO/m5fjoyGo2tZq0btu+75CatvXFYvFYT2ciWnf8snXtukUGN7h8/M/Dm35169rbs+eAMwd2pr1ObNO9z5CJM2+eOX540yqBvkGnAcOGT5lDRMovSUTx0ZH/7NsW9vBBXm52vYZN+o2eyIYXkK/E3tnln/07hkyYydfkyx8+io+OnD+yd5H92n7hjrGZeVZ62l9bVz9/GJSbk9PUvd3gCTOsbGp98JjcvvD32QO7kuJeVatRa8S0uexNHp9f5LGs4qnqMngkxxZDgu6d+WNHXGS4qFBk27Bx71HjXdp4Htzwy9WTh4jI7+p5v6vnf979l0MT1+TE+EMbf4kKfZaTmW5mXb1pm/Yjps3V0tImoondWudmZ85bv+fq6cNRz5/1Gz3x8KZf6zg0/OXPv9lWWI9aR5fmP+06UtoOxkSELho90MSi2rK9x07u3hR8x9vEzKL/2Mnu3fuyBTgSkJOZsWv5/OcPAwsL8jv2H6p4cIjoYw94cmK8WCQiopaduhNRi/ZdDU1MsjMyXoY+cWjcjIgK8/OO79igZ2js3LJNwM3L7Fu17R0Xbj0gMDS0rlmbiBq3anvl+EGJSFxk5YkxUWf+2FXTtn6ngcOJyLmle007+5YdumpqaRmbmde0cwgJupeVnvY2I5S0obiX4bnZmQI9A/aIYvN2Xc4d/P1poD8R5QlziEigp1/art34+6/EmKhO/YfdPHuC4wgAAAB8OUprdhLRskmjIh4/GL9gWaf+w4sMbiBvtyzefvDo9nXPH95v4uY5atoPr+Niti7+Pk8obNK67dSla3UEesovSUQ5WZl/7932+J5PyuvEWvXqe/Ya0G3o14rNpMk/rz604Zda9R2GTJipOOTF1N5ts9JSFfdr2ooNbl16SSSSf/ZuDfK9lRQX49ikeY8RY4sMcVCiqOdP969ZEhsZrqWlM3LGPD6fT0Tsr+KQF8VTNW3FRo4tpiYlHNywKjo8JDMttZZd/bbd+/UYPua+19XNP84govxc4VdtGgyd/H3/MZML8/P+2rb2sb9P2pvXxqYWdRydxsz9ybxadSLaOH9a0O3ro2cviouM8Ll4ZuqK9ZsXTOfz+buv3hPoGxLRi2ePln47XFNbZ+fFuwL9UhtFrPn66+F/714973ftglQsadOt98hp896eFaUnQCaTHd70672blzJSkhu2aNPMvT0R8Xlvm51lOOCJMS+JqEW7rjwer1qNWs6t3ANuXn7s7ysPKP+15TepRNKhz2B5+43H01iwaR8RNWzhRkRN3N5uQiwuVFyzSFS4e8V8vobGiO/mEpFVzToDxk+t6+DExtOwb9LsScCdrPT/TpviG2IXC0TUqmN3Imri5qEjEGSnp8W/jKhp5yAuLCCi0u4ElKHZGXzH69LRP6Keh+gIdBs0bTFkwkx2xVdEZMjj079viQoL0RXotWjfZfC3M3T19D72Eo/FuMMfBZ09uPt58P0ade0m/bSaZfwiQ16UeLnEsRfLJo6MeBI8eMKMgeOnsnfWzpn46O5tdsVa2oVJibnpxbNHF4/sj3jyMD9X2LCFW6OWbboN+V+JQ15cPXnoxpkTyQmxuroCq1p1R34318GlueIx6TJoxLlDv4c9DKxVz2HsD0vq2Dtxl35QHCblAwCoAv5cv/L4zvUSibjr4FE2de0uHT2wYd4UsbhobK4ILW1dIop7GfHXtt8sq9ukvkk8f+j3TQum3TxzvFnbjsKszHMHf494+vCjliwsyP/t+2/9r19q4NqyTdc+IYH+6+ZOSXkdT0RaWjqswX1o4yorm9omFhaKidHW0W3QrCX7J28JaWppFuTlLps00vfSv3XsG7Tq2O2+17Wfxg5Oio/l3rXo8JA9Kxcmxb1ycm1Vr6Hz3lU/lXoQiqWKY4s5mRnbFn8fEnSvjmNDx6bNQwL91s2ZGBnypImbB3uIsqadw4DxU82trLPS05ZOGP7A56aRqVmHfkNzszOvnDi4c+kP7468FhEd3LgyOizE3rmZZ68BGpqaMeEhacmv2QJP7t8lorY9+3H9fFo6RJSfm7N2zmS+hpappVV8dOTvvyzKTE1hQWGOBOz99aeHd735GpqdBgx76Osd5HNTvtqyHPB3HSjEhSL2QkegT0SvY2PYf88e3JOektRvzEQTs/9+dPNq1Ru2cGNNf6lU6nvpDBE5t2xTZN17Vi0SFeQPnjiDddPoMnjkkAkzWJMuMzUl4ukjIqrX0JljQ8kJcURkYmnJ/mtWzYqIcrMzc4U5LKBMPN7mH2esmjZmzy+LAr2vy7+YlZF2+vdtJhbV+o6ZxLX7AAAAX5IyNjvftVu2L51jbGomEYv8rp7fuXz+rmU/NGvbUSIWBd2+cfnEoY9akoj++G3J1ZOHDE3M+owaFxcVeXDDL/7XLxGRppY2C7nu+HmOVCatUdeuSHrsnZuxZmc9p8bsHU0tLSLatXz+mQO7eDxel0Gj4l6+WDt7QsCtK9y7JiosWD9vStTzZxbVbdx79DmyebX8VncRJaaKY4u7Vy4Mun1dV0+/TeeesS/CD2/69dKxAzXq2nn07E9Eunr6A8ZPdXRpTkTr5313/fRfhQUFnfoP1xEIHvjcXD5xVGF+nrzZeeXEIZ+LZ+o1alLXoaGtUyOpVBp0+23z78m9O0TUskNXjmgyEWnraBPRvl9/evXieS07h7Tk1xeO7Av0vso+5UjA1ZOHrpw4mJGS7NGzf74w55/9OxRXW4YDLmOPoInexoJ1dHSJSD42cUigf6D3tabu7Z1b/zeer66eXsMWbiyaTERe504TkXXtuhbW7w1Fcnb/jvjoyC6DRrH3m7q3HzJhRov2XdmnD+94E5FtA2eODeVkZebnConI1MKKRWBNLKoR0ZuEOGFWJnvnn/3bV079ettPs66eOizPOGVodsZEhG6YNyXsUVDH/kNr1XPwv35p08IZMpms+GIrp45+7O/r1qln7fqOl44eWDn1a7Zd5S/xmOyMtK2LZ1tWtzEwNIkKfbppwbTimyvtcoljR1jw/bHfbfZfkajw2X0/ImrTpRfHhUnx3PQmIXb5pFEP7ng5NmvRbej/Xjx7eHD9Cu/zp4tv8cwfOw9u+CUpNrpN1z416zeIeBK88rvRUWHP5MckITpy1/IFltVttHR0I54+3L3iR/bFEks/iUSi5E/2pUEPZQCAKuDFk2Aimrrkt1r1HYnI69+T2jq6UrGIr6nF8S3WMyAh6sXGf26YV6uenyt84HPzxdOHG0/fEOjrLxozKCY8JCTonr1zU+WXjH7+zLJGzVr1Hacs+Y3P54c/CY5/GfHA16vbkP/xNHhElBQb8/3qraxldvPscXliLKvbsOcQRaLCxWxGtTGT9A2Nvc6dSoqNMbeqPvPXrXw+v76zy95Viy8fPTBmbqkxYnYEiMjBpfmi7QeJ6MiW1ZeOHiAiKtboKZ4qji1ePnEwKyPduaX7/E37iGj3ih99Lv5z9eTBKUvWvnj26Hnw/Vp2DkMmzCCi4zvXZ6am1LZvsPyPUxoaGp0Hj1wwqk/AzcuxL8Jq1Xfk8zSIyMDIZPWRc1raOqwR73/9UrCPV+dBI0SFBRGPgjS1ddp06cOxj6zbS35ubrch/+s0YHh+bu70fu3zhNmhDwPdOve4dOyP0hJgaGIW6H2NiGb8stG5pfvAcd/NHtpVfnD8rl/82ANuXauurp5+fq7w/KE9fb6eGHDrckpiPBHlC7NZ/+WLh/fVtK3fc8TYQxt/YR1VFL8+b0TPxJgoY3OLbkO+GjL5e8WPHt71jnj8oHodW3lTXk4kKty+dK6oIL+eU2NHlxYcG8rPzSMibR0B+6KO7tsXecLsvJxsIooKfRoV+pSIiO7dPn960k9rPHv1J6JTezbn5mR98+NyHcHbr8hksir0+CEAAEB5KK3ZSZwz3cnbLT1HjHPv1se6ju1fW9aEBPr9vOeoQ+NmAn39y8f+fB4c0H/MJOWXzBMKs9LTGjRr+c385dXr2Obm5Fw9dTjg1hW3Lj01+Bos2NSu18DRcxazSfkU0yMfcnfvrz+9DH1i38TV1bPzm4RYv6vniWjmL5utatXpPGjknCFd/963nQW8ShN0+2ZGSrK2ru6yvcf1DY1d3Npt+GFq8QYPERVPFccWQwL9QwL9BfqGK/ad0NYVODVvtWflwotH/ug5Ymy7XgN9L50V6BmwZucjP59ngXc1NDVX/nHaxMJSJCqcO6xH6usEr3Onug39msfXIKKstLS1Jy6xOGmHPkOjQp89vOvFAtNPA+4QkUeP/ty/O4/4RGRRvca0FRuJaNX0sSGB/k/v+7do3407AbfOnGAN+6GTZ0ml0iXfDosKfcoOTtkOeL0GjR75+dz692QdhwbC7Kz73leJiDXqJBLJn+tXaOnojvthScTTx8V/hf2rf7559oSmtk7rzj2GTXpvLr6s9LSLxw4QUe+vxhff6ImdG16GPtHV02/XZxDHhgryc9nyOgJd9kJXV4+I8oTCXGEOW+ziX/vZR/7XL8WEP5+wcGXZmp1hjx44Nm1h37jZ8CmzszPSp/RsExcZHh/1oshIwZeOHhAV5Lfp1oc15nctn+976WzQ7eutO/VQ/hKPrSoxJmrF/lO2Tv9v777jm6r3P45/krbp3i1dQGkpUMooe4OAyBQFEQVUwO31ynWvHyqKetXrvIoobsHrXiDKUqaCYNmbsikddKUrSUeS3x8HjjG0IVTK6Xg9H/fRe3qannzOAfXknU8+346jJt90/9WXZR8/mr5ji9LYq3LxcqmmE+kzbPT/Xn8+fde2spIi/8Dg7evXVlVWRjVvmdC+o4vXZWf/0/T7zz/ZrNbuAy+9a/bLItJ3xNh9W/5o2SbZ6enKSooWfjxPRP7x5Iu9h44Ukddn3rNp5dJFH827+7nXlWtyPH3fC5/9GNeqdd/Lxjx9x/XH0/cVGwuCQsKq/7eftcrDw8PFn1STRYcyADQAkXEtRGTO4/d9PvfllQu/6DdibL8RYw1ngjPXWrZpr3werUViGxFpndJJaU9o2bqtiJQWFZ7XI9umdn9s7oIHXnpbeTEQGR2rDhZQBIdHnB0OOvrff587eTi9TeduE267W0SO7d+r9AIoB0zq2EVE9m1Pc31SytvgqX0HKd8OGnPV6R/UcFvmWJWLZ9yd9ruIpHQ/3d1w++PPfbJhX7W3Rzt+/01Eug+6VLm9aJ6QFNeqtYjs3vy7+phBY65S0mQRuWTs1SKydf1q5VkqKyt6DBrquk9E1WvoSKXzIq5VooiUFRldF3B43y4R8fL2ad+tt3LuqX0GqRenFhfc09NT+TTZwo/n3Tqs+7vPzgwKCxcRX/8AEfn8zRet1qrbH3++pjutxPYdff0Cigvy03dvO+jQBCEiP/7vfRG57Orrne6nzWVlL953256035vFtrj/pbeVnTU9kYtbcb/AoOSuPbsOGPLU+1+98s2KLv0uEZEf5s9TmjVWL/yq28Chyo0mAABQ/J3bThHp0n+wiLRMaicingZvZTpWi9M3k8bzeqSvv//MN+c/NndBTHyCiIRHRStvGDse5NIJk10U8/svS1cv+iogOOTuZ/+r1+uP7NstIv5BwVEt4kUkKq5FYGhYxqEDToU5Obx3p4i0S+3uHxisTGsNDAlxPQNXrcrFM+76Y72ItOmUqlzbQWOu+mTDvmpX4duxcZ2ItO3cLSQiUlltuEu/QSKyO22j+pjUfgPVbtz+I6/wNHhvX7/OarVaTKb0XduCQkI79xng4hxVvS89PW5Y6exW7v9dFGAxmTKOHBSR1P6DlfcVBo4ep16c2l3wEddOE5Ftv62+Z/ylM6eOV4afKLedK7/74uTRQ9fcfk94VGy1vxvVslV4dGxVRfmRvbs3/7rS8UcrvvlfhcXSa+hI5fWOo8/mvLho/jsenp4PvfaeMv64pidyHQEnd+3Zvluve55/fe6S9WOn3iYia374uiA3p3a3ncOvvu6xuQuu/cd9IhIYEqok0SaHl12Kowf2ikhSh87Kt61TUkVk/9Y/7+3dfzHYql2HhPYdlT8p5Y9MeVnhyP2XS6rQyGZKZq30gG/fsFZE+lw6ys0XJuo/Tc1iWyp/Md6c9cA3771hraocNmGy4wqKir1bNlWWW/QeHt0HDVP29BoyXER2b/7zn5eWbZKVl06JKaevW4mxsKZ/+6kv6OCEDmUAaABuuPtRU2nJge2bTx49JCJfvf1q90GX3fLo09U8VKdzutdRVxk2+Poqn547862P07v67jyyKD/v41eeUcfXni0y2tUi11vWrfz5m8/U23rlbWcRSVuz4vq+f769nJd50vUFUX5LubMUEf+gIGXDbrOdsyoXz1iYmyMifgGBrp9dREqLjSISHPrn4IWgsPCTRw+VFhepeyKi/7wB7dizX0RM3K5Nv1VWVigfPOw3wtW8C0cOfxC+yvgI1wUEhZSKiK+vrxq8+gUGqRendhf86tvvCQwJ2/rbKpvNNuSKiWsWf7OnID80Mip917aNvywdce1U5e6zWv+Y9WJlZcX3H7618MO33nrygTcWrVM+c5p59PDeLZv0en2/y/4yXLu0uOiZO2/IOHQgJCLy3v+8GRwWLiIunkj586ooNyvflltObwQGh/YaMsKxBebKG/+xbf2azGOHzWVlH774lMHH56aHnjrX5QcAoGlx/7ZTueHUyV8iNoO3j/pVfe9c+fyQU0fvOR9ptVq/mvfaiq8/KTeba6q2WWzzmn6Ul33yvX/PFJEZT7+qJKHKXVBZcZHjXZCI5GZlBASH1HQci7Ikg/+f94d+gcElRqOthttOx6pcPGNh7ik3bzuVWQrKHZEiKDRc6cRU90TE/HkdfPz8+lw64tcli/Zv/cNUVmyzWgeMHu/mZ7DU205l0IRy/++iALWtxO/Mbbmff6CI2Oy2Wl/wzr0H3Pefub98/3m52dy6Q6qXwfD9B3PDIpuZykq/eue/rdp1GDlpWk2/O2bKTWOm3JS2ZsWcx+/79PUX2nfrpY5fW7XwSxHpN9z5A4Jzn3xw/bIf9B4edzzxgvKuhosn8vU7/edlMZmVvxIWi0lEAoKDo+JaOC4LefVtdy/5/OOqivIje3f99NmHtbjtPLRnx0cvzT7zMbsaKRd5wav/XvDqv9WdeTmZ6rb7Lwb9Av6c/hwQGJwjoixw7cj9l0uOegwZnr5r2/bf1/UfecXW31YrbctuvjBR/2lKTOk4+Z8PfPvBm0rb+3fvv5nQvsMN98xs27mb4+OVl2MBwSHq4uHKX1eTwz8vyrsUyrsjOp3Obrcr1+E8XnSDQBkAGoSoFvFPvP2/Q3t2HN2/N23N8p0bf1u96KtLx18b3zZFeUBV1enhtmf/V19lt9kdb+WV/2oqO91/5JfzXtu0cmlU85aT73rAzz/os7kvHtm72/F3dTV/IKgw99TbTz+q0+nU23oR8QsKUhbQGDftDoejnOOWV7kTMpUUK9+WFZ/eUNedc+JYlYtn9A8IypOTZaXFrp9dRIJCQ/OzMx0fWVJYICJBoWHqHr3nn0+q0+kuuXzCN+++vmPDul2bfgsKCVXbq92nJMJ2sbsuwMc/QLkVVj9Jp1wo5eLU7oLr9fpRk6ePmjxduSP/+JVnPTw9E5I7/PjJ+yKy7Iv5y76Yrz544YdvLfti/qx3Pju4a1twWES3gUO9vAxXTr1t4YdvlRiNWcePKM1HG1cuFZF2XXo4vqKoKLe89shdGYcOxMQnPPzae2qvzdZ1K2t6omc+/EZEivJPr6CivDyLiIkzePtUVlbknszw8fcLi4xWWq2Vx9is1v3b0kTkrrF/WULkhn7tlY+/ne8fDQAAjUZNt50JyR31p4fbnh4L6+q2024TEd2Zu8kzN5PVJLAuHrl+2eLFC9718fOb/sCs2PiE35YvXvPD106/rgx8OJvNZntj5r0WU9n4m//Z4cwSDv6BQUrD7N3P/tfxwc1crk6s3Fmpd5tqMqWv4bbTsSoXz6i8319W4sZtZ0iY0yNLjAXqfoX+r/dyg6+Y+OuSRVvXr64ot4jIJWMnnPNZnCiJsPLH4qIAtb1DTbdNZSXqony1u+BKG3i3gUOVbWXASOuOXQ7t3m4qKTq6v+iGfu3VR+7flnZ93+QHX36npKiw3GK5dPy1ygrSLZOSD+/dmb5zqxIoH9ix2ZiX6+VlcFo+7ou3Xl6/7Ae/gKB//fs1ZZlxEXHxRE9/8HVoRFRhXk5RYV5oZDO73V6Un6t8WNBqtRacyq4sL49tlSgiHh4enp6eVRXlNru9ptvOyTMeGjOlmvkbirmzHsjJON6pd//RU27y0Hu8cO8t1upGmfsHBudlnRw5aVq3/kPUnX5num0cnfPFoKn0z/bnkqLCaoNj918uOep32eWfvfGfrb+uPrJvlzHvVFTzlspMCXdemDj+Mz7m+lsGXn7Vod079m/fvGbxN0f27l78yXv3/ecvY7uVv67msjKr1aq01yhDz5UPFlRzWZQrYrfX9G+/0ZNvVP5M4YSRFwBQ31VYzEs+/+jjl55undL50vHXPvza+8oMhJyTGXq9XnlvXPksXmlxUfqureJGPlhr2cePKFPYelwyPDGlc05GRrUj5M5mt9vnPHGfqaTI8bZeRJI6pIpIfnZmUsfUlB59wppFZxw96OlySJ+ItGqXIiLbf1+nfLux5o7ps7l4xvh2KeqkORH5et5r1/dNfuOxe9QenMrycuVHqX0vEZG0NcuV5pQTB/ef/rhf7xrXOFZu5df++N3Jo4f6j7ryb47iclGAct9cVVm5O22D0lS+b+smd07fhdl3XHfrsJ57t2wSkXU/fWcqKerUe4B/YHBEbJy61mJy157K+iTh0bHtunTfsWHt+88/seC1f5vLykQkbe0vyqGCz6ynt3fLRmWIiuMTLfzwrX1b/2gW2+KZD79xXEfFxRNFt2zVLK6FqbR456bflPFqIqK8Wnj/uccemjz67dmPKn9F01avEJH4Nu19/P0dj9bmTF9Dctee3j4+f+fPBQCABq2ysqKm206l6U9ZnEC5tVM+ul53yw/knDiifCZ92ITJKT365Gdn1tQMcbZv3nvj0J4dKd17X3XzXepO5ePtppLi4IjIlB592qZ2P3JgT7Gx0C+gmvRNpdx2Hty9VZm2sWfzxhKjq4kNjlw8o3Lbmb5zm3KntOuP9df3Tb5zTH+73a7cyVdUWJSDKDO79m5NU941r7CYN69ZKSIuplgkd+kZERO3bf2aXZvWt2rX4W++We6iAERbgx0AACAASURBVB8/P2UgyY4N65SmcscFkGt3wT+f+/KdY/p/9/6bylTf7RvW+gUEderV3z8g2PH+rXlCktI5nty1p8Vifnv2wx+9+OTx9H3KQO3MY4dEJOjMh/n2bN4oIokdOjuOL9j9x4Yf5r+r0+kef2uBmiaLiIsn8vHz79x3oIhs+mWp8uFLi8kUG58YGdt83Y/f3nvVpc/84zpleMKuP9ZbTGV6D4+kjqk13XaGN4uu6SLYbDZlHcIrpt3RqVd/Ty+v02nyWe/KtO7QSUSM+XnKsoQ2uy375DGDoTY3tMcP7ss8elj5HOGpkyfUGRSOXLxcciE0sllSh1RzWcm3778pIgNHj1f2n9cLkwM7ty547d8ZBw907T940p33z5zzsYicvbR4+249ffz8KsstW8/MPNmw4kfHYYk1KTebqv23n9KUjbPRoQwA9Z2Hl2H1wq9OHj1UVJAXm9C6OD9v+4Y1nl5ebTt3FZHOffpv/GXp/FeeyTp+5I/VK6JiWxQX5NddMXGJSfu3b1696GurzXpgx9Y2nVK3r1+7ee2KuHO9bbvmh6+VN+d3p/2+58wEq6Hjru05ZHhkbPOcjONP33lDat9B65f+cCrzxOQZDznljE4Gjh6/6vsv03dsefafU4PDwvdtO8fMZUc9Bl9W0zOOnjz9j5XL9m7Z9O8ZN/r5B6StWeHt63vVLTOU2yAR2bnp16/nvdZ14NCR105b+8O3R/bufuKmiUkdO29Y8ZOIXHrVJGXcWLXCIqM69xmwee3Pymw79wuulusCOvcZsOP3X1+feW+/4aO3rF2ld7gtc3H6Lp6udUqnA9s3v/bojOYJSfu3b1b+7ERk6JXXDr3yWvVhH700++dvPh0w6sqJt91tzMtdOP/d3MyM20f0imnRSvng2MDR49Um7hOH9otIbMsExydavfgbZQmXm4f++eG1PsNG3/X0KzU9kYiMnDRt/svP/PfRGS2SktN3bNF7eFw24ToRuWTsxF+XLNqTtuH24b1btG6jVD56yo0eHh6On0ksNhbcOaqfiMx8cz6L8gEAmjIPD08Xt50de/bfvPaXdT995+HpWZibbTGZ6rSYuMQ2IpK+fcvnc18uMRZ6eHmKyLH0PUs++6hr/8EufjH7+NGFH74lIiVFxmf/OVXZmdSxy6Q77+83Yuz6ZT88+8+pQ6+YeGDX9j1pG7oOGNJn2CgXR+s2YGhAcEhpkfHxmyamdO/9+89L/YOCyxymnLkQFhlV0zP2HjJ8yWcfnji4/4mbr26X2uPXpYtE5LoZD+t0OmWMb1lx0Qf/mZXSrU+fYaNS+w3avn7tEzdN7Dn4sh2bfi3My2neuu2AUeNcPPXQK6/98u1XROS6ux9xp1QXUnr0cVHAwFHjv3z7lYUfzys4lZNx9KBj+ubi9F08XZuOXRYvePfb9+fsSttw4uABa1XVkHHXeHp5JaZ0dLx/+/2XpXMeu6dlm3bKzmWp3Q9s3/x/U8c1T0g6efSQ3W6PiU/oNuD035OMQ+kiEhv/lxcsqxZ9qbw18ugNf65YGBIROeeHdS6e6LKrp6z78dtF89/Zuy3tePpeERk5eZqI9Bg8/Iu3Xi42Ft41dmBi+04nDh0QkUsunxAaHlmL2069Xh8bn5h57PDX7/y3fbdeaauWt+/Wa++WTUu/mO/11+6HEddMXfX9l7+v+NFmtUbGNv/l288sprLZ7zv38p+DXZRxgk/dPrnPsFGb1/6iDBpWAl9HLl4uudZjyPCDu7dv/XWVOkD5fF+Y5GVmLPti/h8rl/cdPsbTYNi+fq2IpHTt5fQwX//AcTf98/M5L8598sH+I67IPHZ4/7Y0Hz+/8Tefo0hPg3e1//Zr0abdOc+uaaJDGQDqOw8Pj3tfeLP7oEs3rVr2/Qdz1y1d1H3QsKfe/1K515wy46G2qd0tJtO+rWmT7ryvQ48+IlJpsdRRMWOuuyWlRx9TWen2DWt7Dx151+xXO/cZcGTv7mPp+1z/YlFhgbKxf1vavq1/KP8ryMny8jI88PK8Lv0HH0/f9/0Hc/WeHjc++OSoSdNdH61tp65T73/M0+C9d8umY+n7ZjzzqrK/sqL8nKfg4hmbJ7Z54p1Pkzqk7knbkLZmReuUzg++8o7S09HvsrGx8YnlZvP3H71tLisNCAqe9e6nqX0HHjuw5+dvPrPbZcItM6bd/4Trp+7af6jymbhWZ2aV1JrrAm6b+VxC+46mkqLVi77uOWR438vGiEhVRYXr03fh6lv/1WfY6NDIqEN7d8XEJ9z2+PPdBgxx/SshEZGPvvFBp179ReTk0UMBwSEjrp168yOz1QeUFhWJiO9fP0mnTFI7X8Ovvv7q2+8RkfQdWyJi4h5+9T1l/ev2XXve+8Kb7br0MJUW79++uXlC0tT7Zv79NB8AgMZKr9e7uO0cMu6aAaOu1Ol0+7enJXfpddUtd4lIhRt3X7XTc/DwPsNGBYWFb/xlSWBI6D3Pzxk+8QazyZy29mfXv1h8Zp2xEwf3q7edyjvZ0x+cNWTcNVUVld9/9PbR/XvGXH/LHU887/poPn5+974wJzg8Ivv40d9/XnrDPf+nDHWtqnTrxGt6Rm9fv8fmzu8zbFROxvHVi74KCY+46ZGnlLuU6Jat+g6/XFkaLuPQfhG55/k5l024rqy0aPnXn+Rlnexz2ZjH5i5QFqWoSbdBQ5X+8X7Dx7pTp2suChhz/c1Kw+m6Jd8HhYQqi8hVVVa6Pn0Xug+6dPzN/0xI7nhk3y7fgIAR106ddOf956zwvv/MHTDqCh8//4wjBz09vXoNHfnoGx8pE7rV8SzqgA5F7d4RadU25f6X5oVFRqfv2KLXeUye8ZDS9BAQFDzzzQW9Lx2p0+nSd2719PIaNmHKdf+qfZo/6a4HkzqkHjuw99Cu7Tc+/OSUGQ/FJbbZvO4XY16u48PiWrW+94U3W6d03rRy6Y+fvJeQ3OGR1z9ITKlxdZNqVVVWiEibTl3HTLl55XdfGPNy49u0v/f5OWc/0sXLJdfUBQlbtesQ3bKVsn1eL0z6jRh73d2P2Oy2H//3/sIP37Jaq2649/+m/Ouhsx95+XU3T73/cW9fv1ULv9y/La1tavcn3/sy6lyDVmp60e04WwaOdO58ThkAcAEdKit67sDmW+L/bqSIhsVms7143607N/528yOzh1x5jdbl4O86WGbcVVzwfId+bjwWAADNXLVxyYzETr4efDq5aVn48dtfvf1a/5Fj/zHrRa1rAZqK77IOj4qKHxzhapn6RoP/qAAA6qNdf6xf++N31f4oIbnDOTtq65uX7r89Lycr49CB5q3bDhxzlbKzIDfn8zdfqvbxPj6+Nzk0814Ey7/+5OCu7dX+qP+IK5wWMAEAAGg06tUt2d/35Vuv7N++ef/2zZ4G76tv+3O47UcvPeW46pqja+64x3HtirrWyO7za60xXYf687cLFw0dygBwsdGh3ATdOqxnVUV5cree0+9/wsWcZTQgdCgDABoEOpSbmlcf/ufmtb8kJHe45h/3KcPHAFwcdCgDAIAL6d2f/9C6BAAAADR+977wptYlAGj8WJQPAAAAAAAAAOAWAmUAAAAAAAAAgFsIlAEAAAAAAAAAbiFQBgAAAAAAAAC4hUAZAAAAAAAAAOAWAmUAAAAAAAAAgFsIlAEAAAAAAAAAbiFQBgAAAAAAAAC4hUAZAAAAAAAAAOAWAmUAAAAAAAAAgFsIlAHgYvPx8Azw8NK6CgB/i9Uukd6+WlcBAMA5tPDzr7LbtK4CABo/g97Dz8NT6youEgJlALjY4nz8j5qKK2xWrQsBUHuZlrJYb3+tqwAA4BwCPLyyLCatqwCAxi+9tDDRP1jrKi4SAmUA0MDwqJa7Swq0rgJA7R01FQ9u1lzrKgAAOIfhUfEHy4xaVwEAjdxxc0mbgJAIg4/WhVwkBMoAoIE7EzrtLzUeKOXmHmiQvjx58Ibm7WK8/bQuBACAc7gkPDbRL3hJzjGtCwGARiuvwvJLbsbMdj21LuTi0dntdq1rAICmyGq3P7x7faTBx1Onb+bja7Xxb2OgvrOLnLSUZprLprRoNyA8RutyAABw15zDO4yV5V56fYy3v40QAAAuBL1OV1hZbqqqPFBmfL3zJYGeTWipJAJlANDSqtyMg2VFxsrykqoKrWvBhZSefjAqKiooKFDrQnAhRXj5xPoGDIiIjaY3GQDQ0Gwtyt1TXJBbYSmoMGtdC3AO+/fvb968hb8/d1yo1wx6zxAvQ9uA0OHNWmhdy8VGoAwAwIV31113TZ06tVevXloXAgAAADQw06ZNe+SRR9q3b691IQCqxwxlAAAAAAAAAIBbCJQBAAAAAAAAAG4hUAYAAAAAAAAAuIVAGQAAAAAAAADgFgJlAAAAAAAAAIBbCJQBAAAAAAAAAG4hUAYAAAAAAAAAuIVAGQAAAAAAAADgFgJlAAAAAAAAAIBbCJQBAAAAAAAAAG4hUAYAAAAAAAAAuIVAGQAAAAAAAADgFgJlAAAAAAAAAIBbCJQBAAAAAAAAAG4hUAYAAAAAAAAAuIVAGQAAAAAAAADgFgJlAAAAAAAAAIBbCJQBAAAAAAAAAG4hUAYAAAAAAAAAuIVAGQAAAAAAAADgFgJlAAAAAAAAAIBbCJQBAAAAAAAAAG7x1LoAAAAaIX9//++///7gwYMxMTHR0dExMTEhISFaFwUAAADULxUVFQUFBYWFhQUFBQUFBUajMT8/v7Ky0mAwaF0agBrp7Ha71jUAANDYFBUVLV26NCsrKysrKzs7Oysrq7y8POaMqKio2NhYJWiOiIjQulgAAACgThiNxsLCwsLCwvz8fKPR6JgaK/srKirCw8NDQkLCwsLCwsJCQkLCw8PbtWvXvXt3rWsHUCMCZQAALgaz2azmy9nZ2ZmZmcqG0WhUu5jVr0rcrHXJAAAAQI0sFosSCju1GDt+GxQUFBoaGhoa6pgah4aGKl9DQ0MDAgK0Pg8A541AGQAALVVWVqpdzE5f1WTZKXH29GRiFQAAAOqW2lBcU2pstVqVUNgxJlZSY3WnXs/aXUAjRKAMAEA9lXWGEjGrG6GhoWojc1RUlDpJw8fHR+uSAQAA0ABYLBY1KVanTzilxiEhIWou7BQTKzmyv7+/1ucBQBsEygAANDC5ublO7cwKX1/fs6dnxMTEBAYGal0yAAAALh7HmcWOMbGaIIvIOZuLdTqd1ucBoJ4iUAYAoJEwGo3KaOasrKycnBx12263O45mVlLmmJiY0NBQrUsGAADA+TGbzTXNLFa/KkvbhZ5x9qp3vr6+Wp8HgAaMQBkAgEautLRU6WXOzMzMyclRO5rNZnO1Hc3NmjXTumQAAIAmyikadmouLigosNvtZ0+fcEqNtT4JAI0cgTIAAE2UxWJxms6sfC0oKIiJiYmKinJaEjAmJoZPPgIAANSa2lzsYiSFGgqrIymcBhn7+flpfR4AmjoCZQAA8BdVVVXZ2dlKR3P2GZmZmVlZWcoagGq+rAzQiI2N9fLy0rpqAAAAjRUUFDjGxOpUCnVbRNSk2HEkhWNqrPVJAMC5ESgDAAB3OTYyq18zMzODg4OrbWqmgwYAADQOJpNJHVhcbWpsNBod5044xsRqaszkYgCNA4EyAAD4u/Ly8pyampVJGl5eXrGxsUpfs0IJnYOCgrQuGQAA4DS73a62EqupsdMwCr1e79hcXG1qrPV5AMBFQqAMAADqSlFRkdrLrGwoobPVaq12PcDw8HCtSwYAAI1NWVmZ2krs2FCspsZGozEsLMwxJnZa8i4sLMzHx0fr8wCA+oJAGQAAXGxlZWVZWVk5OTlKR7MaOpeUlChDM5zGNEdHR2tdMgAAqI9sNtvZzcWOw4sLCgo8PT3VFe2qTY1DQkK0Pg8AaEgIlAEAQH1RUVGRmZmZk5OTdYayferUKTVfVr6qkzQ8PDy0rhoAANSV0tLSapuL8/Pzlf3FxcVqK7GaGjsNo/D29tb6PACgUSFQBgAA9Z3NZnNaDFDdiIiIUBuZY2Ji1FUBDQaD1lUDAABXrFZrYWGhGg0r2+okCiU1NhgMaiuxY0NxeHi4sp/mYgC4+AiUAQBAA6a0MKtNzeoMjaCgIHUNQCViVrb9/Py0LhkAgCahtLTUaV07p9S4tLTUqblYnUeh7uQdYgCohwiUAQBAI5SXl6euAZh9RmZmppeXV7XrAQYHB2tdMgAADUZVVZXj0naOqbGyJz8/38fHx3VzMf/xBYAGikAZAAA0IUVFRU7TM5SvlZWV1a4HGBERoXXJAABcbCUlJU5txU6psclkUvuIFY7NxUpq7OXlpfV5AADqBIEyAACAmEymatcDLC4uduplVrNmrUsGAKA2qqqq8vPza2ouViYa+/j4OK1r55QaBwUFaX0eAADNECgDAADUqKKiotqO5pycHHUNQMegOSYmxsPDQ+uqAQBNV3FxsWM0rCTFjo3GFotF7SN2So2VzuKwsDBPT0+tzwMAUH8RKAMAAJw3u92uNDIr+bLa1JyZmRkeHl5tU7OPj4/WVQMAGrbKykp1RTunkRTKYneFhYV+fn5nNxerLcZhYWGBgYFanwcAoGEjUAYAALiQTp06VW1Ts6+vb8wZUVFRSndzTExMQECA1iUDAOqFoqIitaG42tTYYrEoHcQ1NReHhobSXAwAqGsEygAAABdDYWGh2tScnZ2dmZmpBM06nc6pozk6Ojo2NjYkJETrkgEAF0xFRYWaDjvOLHbcGRAQcHZDseM270ECAOoDAmUAAAAtlZSUVNvRbDab1Y5mx0nNkZGRWpcMAHBmNBpdNxdXVFSoK9o5pcbKYnehoaFM4QcANAgEygAAAPWRxWJxnM6sbhcWFlY7ozk2NlbrkhuPd47uSivM9dbrD5UVa10LLpikgGCdyCURcVfFtta6FjQwFotFXdHOKTVWvw0KClIbiqtNjWkuBgA0GgTKAAAADUlVVVW1Hc1ZWVmOjcyO215eXlpX3WCU263Xblw6Jjo+0uDXzMePW+XGxCaSaS49YS4xW62PJ/fUuhzUI44Nxeokivz8fDU1tlqtTgMonKYYh4WF6fV6rc8DAICLhEAZAACgkVCTZaem5uDgYKd2ZmXbz89P65LrnbEbFt+dlBrgQQTfmG0szM6xmP/doa/WheBisFgsjkmx47a6JyQkxHVzsb+/v9bnAQBAPUKgDAAA0Mjl5eVV29RsMBhiYmKioqJiY2MdZ2gEBQVpXbI23j6yy6DXpwSGaV0I6tza/MzuwZGXNmuhdSH4uxyjYaevyobdblebi51SY/VbnU6n9XkAANCQECgDAAA0UUajMTs7Ozs7OzMzU9lQOpqtVqvjmObY2NioqKiYmJjw8HCtS65b0zf/PDEuKdzgo3UhqHObjacqbLZ7k7poXQhcUZqL1QEUhWc4NRerDcXVpsZ8FAMAgAvOU+sCAAAAoI2QkJCQkJDk5GSn/WVlZY69zHv37lW2S0pKlF5mx+kZSo+zRmdwIZltVaEGb9LkJiLa229/qVHrKpq6wsLC/Px8dWk7p5EU+fn5drtdjYbDw8NDQ0Ojo6NTUlLU4LjRv8sFAED9RKAMAACAv/D3909KSkpKSnLaX1FRkZmZqU5nXr9+fU5OTmZmZm5urmO+7NjU7OHhodFJnDed6I6UFWtdBS4Su06yLGVaV9GYmc3mamdQOCbISkysthiHhIR06NAh9Izw8HBfX1+tzwMAAFSDQBkAAABuMRgMrVq1atWqldN+m83m2NG8bdu2JUuWKN9GREQ4LgOohs7e3t4anQSAv8tut9e0zJ0ym6KgoECn0zktbRcbG9uhQwfHBFnr8wAAALVEoAwAAIC/Ra/Xx8XFxcXFnf0jpZ1Z+bpv375Vq1YpTc3+/v6OHc1q1hwQEKDFGQD4k8lkcoqJnZa5MxqNjkOKlbw4Li7OcX6xjw/TYwAAaLQIlAEAAFBXoqKiqp2wXFBQoDY1Hz9+fOPGjcq2TqdTxjQro5nV7ZCQEC3KBxobm83mNIlCGUDhuFOv1ysDi9Vl7po3b965c2c1QQ4NDdX6PAAAgJYIlAEAAHCxKT2MHTp0cNpfUlKSmZmZfcaOHTuUDYvF4jSdWdmOiIioXQH9+/cfMmTI/fffTzSGxqS0tNRx9ITTJIrCwsLi4mLHMRTK1+bNm6uTKEJDQ2kuBgAArhEoAwAAoL4IDAxs165du3btnPabzWbHMc1r165VtgsLC2POcBqg4fqJLBbLTz/9tHfv3ptvvnn06NF1eU7AhWG1Wh0XtXNKjZXg2MvLyzEsDgsLa9myZZcuXdSdNPsDAIC/j0AZAAAA9Z2vr29iYmJiYqLT/qqqqqwzcnJyNm3apIbOar7s1NTs6emprCqm1+uPHTv24osvbtiw4b777vMNDtLo5ABRmoudRk84jTAuLS1VBxYrAXFISEh8fLz6bWhoKMtdAgCAi4BAGQAAAA2Vp6dnixYtWrRocfaPlJRZyZd37dq1YsWK7OzszMzM0NDQ6Oho9WElJSVLliw5cODAlOnThOkXTVhZWdmcOXNWrVq1dOnSC37wqqoqtae42vXuCgoKvL291bxY+dqqVatu3bqp3wYHB1/wwgAAAGqBQBkAAACNUE2DL/Ly8rKysqZPn+64Mz09/aWXXgp/9v6LWCDqkUWLFn366afp6em16/AtKSlxHD2hZsTqtslkUsJiZU6xEhAnJiaqzcVhYWFeXl51cGYAAAAXHoEyAAAAmpCIiIg777xTp9Mpgy9EJCQkJCYmZtCwS3/SujZcfPv37583b97WrVtLSkp0Op3ZbHZ6QGVlpeMYCjUmdpxl7OvrGx4e7jh6onXr1j169FD3BAUxUAUAADQeBMoAAABoWsrLy+12u5+fX7NmzQYMGDBq1Kjk5GSLzfrTpgs/6wD1ll3knXfeWb58+dGjR9WdOp3uhRdeUNe7KygoKC8vd5pEERYW1rp16/DwcLXdWBnMDQAA0ERw6wMAAIAmZ+zYsZdffnmPHj20LgSaOXzoUNoHH1RVVTnu1Ol0SUlJanAcFhYWEBCgXY0AAAD1EYEyAAAAmpaFCxfWxWFXLvzig+dntencbda8T0Xk7iuH5J/Kevi/73fq1b8unq6pmTf7kXVLvh895aYpMx66IAds0bLloHHj1q9ff+rUqfLycg8PD2X/hAkTLsjxAQAAGiu91gUAAAAADdXd44a8OesBZTskLDK5a8/4NslaF3XB5GadvL5v8sqFX2hdSJ0weHk98sgjixYtmj17du/evcPDw202m81m07ouAACA+o4OZQAAAKA2DuzYkp+TpX7bbeDQbgOHalrRBbZ++Q9al3AxDB8+fPjw4UeOHFm8ePGyZcu0LgcAAKC+I1AGAAAAztvP33z20UtPiciG5Ys3LF/8xLxPM46kO468cFNpcdG8px/Zt+WPmPiEkZOmnTx6aOGHb424ZuoN9/6fiBQXFnz6xvP7tm02lZZ26Tdowq3/ioprISJLv/j4k9ee63PZmGFXTfphwbv7t6W1SGw7/aFZ8W3aK4dd99PCld99duLwgZj4xH7DLx81abqy/7bhvU0lRQ++/M7ybz45sm/33B9/Ky0u+va9OTs2rsvLzmqRmDRw9LjhE28Qkf+bOu54+j4R+eD5WfNffuajtTtdHLYmx9L3zpw6PiSi2VPvff7VvNe2/rYmJCziyul39BsxVnlAbtbJBa8+e2Tv7tKiwrDomC59L5l01wNeXgYRKS0yvj374X3b0irKLUOunKg8Xqc//QnLmq5MrSUkJMyYMWPGjBl/5yAAAABNASMvAAAAgPOW0L5jcteeItK8ddtxN90ZHhVdu+O8/9zjW39dpdPrE1M6fjH35Q3LF4uIp8EgIuVm01O3T/51yaL4Nsm9hgz/Y/WKx6dPyDl5QkS8DD4iknn00NuzH4mMifPy9knftW3e048qx1y18Mt5Tz988ujhERNvsFlt//vv8wte/bfyIy+Dl4jMf/WZo/v3tOnYVUQ+/M+s5V8tCAwJu3zKjRlHDs1/5dnff14iIkOvvDY8OlZEug4YcuX0f7g+bE28vLxFxGIqffH+O/QeXqGRUSePHnr32ZlF+XlKKPzkrdduWbcyKDRs8BUTTSVFy76c/9aTp0ckv/fc49vWr9F7eA4dd822X9dsXrdSPayLKwMAAIC6RqAMAAAAnLfWKZ2UQLlF67ZX3/qv8KjYWhzEmJf7x+rlIvLP2S9Pf2DW7Pe/KirIExGx20Vkw88/5Zw4Fh4Vc/dzb9zy6NPT7n/MVFq89LOPRESnFxE5nr7vwVfemf7ArHuee135tthYICLff/CWiEy66/6Jd9z7zEffRMY2X/bl/KKCfBHR6zxEJCAo5LVvf7n3hTnmsrLiwoLkrj1v+79nr779niFjrxaRTauWiciwCZMjY+JEpOuAweNvutP1YWui1+tFxGIyDb/6uttmPvvkO5/7+gdWVlbs3ZYmIks+/7AoP69lm+TZH3497YHHZ879REQ2rVx64uB+Y15u2poVIvKvZ1+d/sCs2R98ZbVWunNlAAAAUNcIlAEAAABtnDh8QES8vH069uonIsHhEV37DxYR0elE5Nj+vSKSkNxRiWWTOnYRkX3b09Rfb9kmOa5VaxFJTOms7CkxFpYYC/NPZYlIUkqqiOh0usT2HUVkv8MvDhpzlZfBW0R8/f1nvjn/sbkLYuITRETpszaXlZxdqjuHdaHX0JEi4uPnF9cqUUTKiowisuP330Sk+6BLPTw8RKR5QpJyOrs3/3543y7lyrTv1lu5Mql9Brl/ZQAAAFB3mKEMAAAAaKOksEBEfH19lURVRHz8AkTEbrOJiMVUJiJpa1Zc3zdZ/ZW8zJPqtrevn7Lh5WXQ6XR2u91utyu/pQxBdnyuvOxMdTsi+nQ/tdVq/Wreayu+/qTcbHZdqjuHdcHHz1/ZMPj6iojNZhOR0mKjiASHRqgPCwoLP3n0UGlxjlTRkwAAEd9JREFUUVBIqdOV8QsMcv/KAAAAoO4QKAMAAADa8PEPEBFTWandbtfpdCJiKilWl57zCwoSkZQefcZNu+PP39Hpqj2U3W5X/i8gOFjZc/vjz4U3i1EfEBnbXN3We55OadcvW7x4wbs+fn7TH5gVG5/w2/LFa374utrju3NYdyiJsF3sIhIUGpqfnVlWWqz+VEnYg0LDLuCVAQAAwIXFyAsAAACgNpSgs7K8vNZHSEzuKCJVlZW70zYoi9Tt27pJ/WlSh1QRyc/OTOqYmtKjT1iz6IyjBz09z9ER4usfGBufKCKVlRUpPfqk9OiTfyor71S2t5/f2Q/OOXFEmZgxbMLklB598rMzRcRus599gud1WDel9r1ERNLWLFcalk8c3J9x5KCIpPYemNCug+OVKcrP+/tXBgAAABcEd10AAABAbYRGNhORnZt+/Xrea10HDq3FEUIiIrv0H7ztt9Wvz7y33/DRW9etdvxpj8GXRcY2z8k4/vSdN6T2HbR+6Q+nMk9MnvFQ29Turg87cvK0D56f9dF/nso4dNBiKlv747eBoWF9ho44+5FxiW1EJH37ls/nvlxiLPTw8hSRY+l7lnz20ajJ00MimonIL99+bszPHTv1dvcP66aR105b+8O3R/bufuKmiUkdO29Y8ZOIXHrVpKgW8SLSuc+AHb//qlyZLWtX6R3y4lpfGQAAAPx9dCgDAAAAtdHvsrGx8YnlZvP3H71tLiut3UFuffSZhPYdTSVFqxZ+1XXgkK4DLxURL4NBmYz8wMvzuvQffDx93/cfzNV7etz44JOjJk0/5zGHXnnt5H8+EB4du/yrBeuX/9B3+OWz3v7U4ON79iN7Dh7eZ9iooLDwjb8sCQwJvef5OcMn3mA2mdPW/iwioydN9/ULyDx2eOlnH+tE5/5h3RQQFDzr3U9T+w48dmDPz998ZrfLhFtmTLv/CeWnt818Trkyqxd93XPI8L6XjRGRqoqKv3NlAAAA8PfpTk9bAwAAAJowi806adPSR9pe7BbXvVs22W22lm3bBwQFi8gTN008vHfn7Y+/MHD0lRe5kiYlw1K6JvfkG6mXaF0IAABAw8PICwAAAKAOffTSU6bS6vuXr7njnkUfz9u56beY+ITel47KOJR+eO9Ov8Dgzn0GXPQya6kgN+fzN1+q9kc+Pr43PTL7olcEAACAukWHMgAAAKBZh3KJsfCDF2adysw4eSRdp/foPnDI5LseDI+KvchlNDV0KAMAANQaHcoAAACAZgJDQu9+7nWtqwAAAADcxaJ8AAAAAAAAAAC3ECgDAAAAAAAAANxCoAwAAAAAAAAAcAuBMgAAAAAAAADALQTKAAAAAAAAAAC3ECgDAAAAAAAAANxCoAwAAAAAAAAAcAuBMgAAAAAAAADALQTKAAAAAAAAAAC3ECgDAAAAAAAAANxCoAwAAACIt97D39PLardrXQguBovVGuntq3UVAAAADRKBMgAAACA6kQiD70lzqdaF4GLINJe29AvUugoAAIAGiUAZAAAAEBG5KjYxzXhK6ypwMWwqPDU+prXWVQAAADRIBMoAAACAiMglEXE9w6IWZx/VuhDUrU8zDsxK7hXsZdC6EAAAgAZJZ2dOHAAAAHDGJyf2p5cabXZ7lI9vhY1b5cbDS6fPsJQYKyv+kdCpS3CE1uUAAAA0VATKAAAAwF8cKSs+WGbMLbeUWSu1rqXObdy4MTIyMjExUetC6lywh3esn3+v0CiDno9pAgAA1J6n1gUAAAAA9UuCf1CCf5DWVVwk2Qu+7eIXObZVB60LAQAAQMPAm/MAAAAAAAAAALcQKAMAAAAAAAAA3EKgDAAAAAAAAABwC4EyAAAAAAAAAMAtBMoAAAAAAAAAALcQKAMAAAAAAAAA3EKgDAAAAAAAAABwC4EyAAAAAAAAAMAtBMoAAAAAAAAAALcQKAMAAAAAAAAA3EKgDAAAAAAAAABwC4EyAAAAAAAAAMAtBMoAAAAAAAAAALcQKAMAAAAAAAAA3EKgDAAAAAAAAABwC4EyAAAAAAAAAMAtBMoAAAAAAAAAALcQKAMAAAAAAAAA3EKgDAAAAAAAAABwC4EyAAAAAAAAAMAtBMoAAAAAAAAAALcQKAMAAAAAAAAA3EKgDAAAADRdwcHBBoNB6yoAAADQYBAoAwAAAE1XUVFRRUWF1lUAAACgwSBQBgAAAAAAAAC4hUAZAAAAAAAAAOAWAmUAAAAAAAAAgFsIlAEAAAAAAAAAbiFQBgAAAAAAAAC4hUAZAAAAAAAAAOAWAmUAAAAAAAAAgFsIlAEAAAAAAAAAbiFQBgAAAAAAAAC4hUAZAAAAAAAAAOAWAmUAAAAAAAAAgFsIlAEAAAAAAAAAbiFQBgAAAAAAAAC4hUAZAAAAAAAAAOAWAmUAAAAAAAAAgFt0drtd6xoAAAAAXFTjx4/38PAQkby8PF9fXz8/P71e7+vrO3/+fK1LAwAAQL3mqXUBAAAAADRw9OhRZaO0tFRErFbr4MGDtS4KAAAA9R0jLwAAAIAmZ/To0U4fVYyMjLzxxhu1qwgAAAANA4EyAAAA0ORMmjQpPj7ecU/Hjh07d+6sXUUAAABoGAiUAQAAgCYnMDBwzJgxOp1O+TY8PHzq1KlaFwUAAIAGgEAZAAAAaIomTZrUsmVLZbtz585dunTRuiIAAAA0AATKAAAAQFPk7+8/btw4Dw+PsLCw66+/XutyAAAA0DAQKAMAAAANhk2koLL8VIU5p9xksVlFxFhZnlNuKnfYrrTbRKSgwpJTbqqy20Ukv8KSU26y2u0ikldhzik32UREpP/okVHtklJTU1NTU0+Vm06Vm5RnySk3nSo3K0+XU27KqzCLiNVuzyk35VdYRKTKbs8pNxVUWESk0m7LKTcZK8tFxGKzGisrtL1EAAAAqFM6p8WdAQAAANQr5Tbrr3mZVpEwg/eirCNZljKbSGFFeY+QyOa+AZsKczItpj6hUdE+fr8VZOWWWwaGx4QbfNbknSysrBgcERvi5b0yL6O4snJYZFyAp2FZznGzzTqiWQtfD8+fco5W2Oxjo1t56HSLso+IyBXRCVa7/Yfsowa9bnRUK7O1atmpE756jxFRLUurKn7OPRnk5TU0ormxsnx1Xmaol+GSiLj8Csu6/KxIb5/+YTE55aYDpcYwg8+U5m1tYi+3WvuERWt9/QAAAHAhESgDAAAA9VR2ucnXw/P1g9sPlBlzLCatyzk/Bp0+0sc30T/48XY9K+02Lx0fjgQAAGgMCJQBAACA+uiNwzv2lRSeMJUooy0armbeviFe3sObtbwiJkHrWgAAAPB3eWpdAAAAAIC/OFVuXnHq+LKc4xUNPEpWnCo3nyo3Z5rLAj29LolsTqMyAABAg0aHMgAAAFCPnKowv35w+6bCHK0LufAMev2giLiH2nTTuhAAAADUHoEyAAAAUF9sL86fvW9jSWWl1oXUoVAv7096DmekMgAAQAPFbRwAAABQX6zOzWjcabKIFFaWr8o9qXUVAAAAqCU6lAEAAIB64cFdv20vytO6iovBS6+/K7HzqKh4rQsBAADAeaNDGQAAANDe20d37SzO17qKi6TSZvvg2J4/Ck9pXQgAAADOG4EyAAAAoDG7iKmqytaUPjtYVFmxr7RQ6yoAAABw3giUAQAAAI3tKs5fnnNM6youtvX5WU0oQQcAAGgsCJQBAAAAjf17f5pN6xpcsFrKf75kQvaKtRf2sIfKjDN3b7iwxwQAAEBdI1AGAAAAtLS7OF8nOq2rcKUk/Yjdag1IanWhD6zbV1pYZq260IcFAABAHSJQBgAAALSU4B+cV2HWugpXStIP670N/vHNL/iRY338vfUeF/ywAAAAqDueWhcAAAAANGkrco7X6fELt+0+/s2PhVt2GsJCmw3s3frWKTqdTkS2PDDbLzY6oHX8gTkf6r0N4T27JN9/u1eAv4gYd+079N5nxfsPBrZJjL/2itIjx4PattbpL3wzyuGyIrvYpX43aAMAAMARHcoAAACAlpacqsNA+cT3S9P+9XhQu9b9Pn0zcdrE418vPv7VYuVHpuOZBVt2WM2WAV+/0/WFx3JWr89evkZETBlZWx942hAS1OfDV9v8Y2r62wvy/9gekBRfF+VV2e3/Sd9aF0cGAABAHSFQBgAAALRkqIPOX4UlN//A6x8k3Tol4foJhuCg6GEDW4wflb1stYhYzRZz9qnw3t3iJ11pCA4K7tDWN7qZJTdfRI5/vdjDzyfl0bt8o5sFt2+TdMsUc0aWf6sWdVSkuaqyjo4MAACAukCgDAAAAGipc1BEHR05Z9V6u83W4qrR6h5DeKglr0BESg4dFZst7vLLlP12q9VyKs+nWYSI5K1Pazawt4e39+lfCQ0WkcDWF3xFvtMmxiXV0ZEBAABQF5ihDAAAAGjpiKnYLnZdHcwRLjlw2F5VtWrEFMed/q2ai0jpoWN6b4N/fJyys+xYhq28wr9lXHmB0ZyZE5zSVn28OStHRAKS6iRQtouYrVV1cWQAAADUEQJlAAAAQEtl1sq6yZPFaraE9UhNmDbRcaenv58SKDuus1d6+LiIBLZtbc7MFhHvZn82TRftTfdrGacs1nfB6cS+vSi/T1h0XRwcAAAAdYFAGQAAANDS4Ii4PcUFdXFkQ1iw1WwO69pR+dZus5kysvxbxolI6ZHjAa3/XGev9Mhx37hor0B/k90uIrbyCmV/ZXFJzi+/hnbpWBfliUiAp6FTcHgdHRwAAAB1gRnKAAAAgJaujEkMM/jUxZFjRw4t2LKrYMtOu9Vq3Llv51OvHJjzofKjkgOHAxJbqo8sO3IiMClBRAIT470jwk4uWl6wdVf+pq17X3q7ymzxT6irFfm6hzTrR3syAABAg0KgDAAAAGjJWFkeUTeBcnCHth2fuGfvi2/9fMmEnU+9otPpOj15v4iYMrKqykwBCX8GymrDst7g1fHxe8qOZWye8diuZ/7bfNxIm6VcGbtcF5r7BdTRkQEAAFBHdHa7XesaAAAAgCbtwV3rtxflal3FxabX6a5v0e76Fu20LgQAAADngUAZAAAA0FheheWBnb9mWspqekD6W/Mri0ucduo8POxWa7WPN4SGJN123YUqz3Qi8+in31X7o6oyk7LK39lCUlNiRw5xcdjkwNAXOvTz9WBZFwAAgIaEQBkAAADQ3h+Fp2bu2aB1FRePn4fnR92HhXh5a10IAAAAzg8zlAEAAADtBXp6BXkatK7i4mnm7UuaDAAA0BARKAMAAADaSw4MvSE+uYnMfwjxMtyZ2EnrKgAAAFAbjLwAAAAA6os9JQUP7vq10taYb9Fjffz/mzoouCm1YwMAADQmdCgDAAAA9UVKYNhlzVpqXUUd8tTpnkzpTZoMAADQcDWJj9QBAAAADcU9rbtYbfZtRXk55Sata7nAWvoGjI9t3co3UOtCAAAAUHuMvAAAAADqHbO16qWDWzcW5FTYrFrXcgEEexruTOzUKTgiwuCjdS0AAAD4WwiUAQAAgPqowmZ779juwsryLYWnSqoqtS6nluJ8/MusVZNbtB0fk6h1LQAAALgACJQBAACA+stsrfL18Lxnx7rcClOwl7epqiq/wmyxWnU6EdHZRXR2u+h0druITsQuOp3YxS7KLqf9yrbYdcqrAJ3u9LbYRXRyeofdrtPpxC5/PkaU3X9ui5x5bjnzWkI5jojdHuRpCDF4l9tsOrHfntBxQHjs6acFAABAo0CgDAAAADQAJy1lwZ6GAE+vr04eNFkrr2+R7KHTvX5ou16nuyuxc6Xd9tbhnb4enre26lBmrXr/6O4gL8P0lu0LK8sXHN8XYfCd0qLtqXLT5xnpMT7+E+OSMsyl32YeauUXdEVMwpGy4h+yj7QJCBkVFb+/1Lgs51j7wNDLmrXcVZy/MjcjNTjikoi4rUW56/Iye4ZG9Q2L3liYs7Egu394TPeQZmvzMrcV5Q6OjOscFPFL7olss6lPeHRr/+C9JQUxPv4hXt5aXzYAAABcYATKAAAAAAAAAAC36LUuAAAAAAAAAADQMBAoAwAAAAAAAADcQqAMAAAAAAAAAHALgTIAAAAAAAAAwC0EygAAAAAAAAAAtxAoAwAAAAAAAADc8v8oTIAJkU/1jAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize_graph(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n"
+     ]
+    },
+    {
+     "ename": "NotFoundError",
+     "evalue": "Error code: 404 - {'error': 'Not Found'}",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNotFoundError\u001b[39m                             Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[23]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m result = \u001b[38;5;28;01mawait\u001b[39;00m graph.ainvoke(input_data)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/__init__.py:1613\u001b[39m, in \u001b[36mPregel.ainvoke\u001b[39m\u001b[34m(self, input, config, stream_mode, output_keys, interrupt_before, interrupt_after, debug, **kwargs)\u001b[39m\n\u001b[32m   1611\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1612\u001b[39m     chunks = []\n\u001b[32m-> \u001b[39m\u001b[32m1613\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mfor\u001b[39;00m chunk \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.astream(\n\u001b[32m   1614\u001b[39m     \u001b[38;5;28minput\u001b[39m,\n\u001b[32m   1615\u001b[39m     config,\n\u001b[32m   1616\u001b[39m     stream_mode=stream_mode,\n\u001b[32m   1617\u001b[39m     output_keys=output_keys,\n\u001b[32m   1618\u001b[39m     interrupt_before=interrupt_before,\n\u001b[32m   1619\u001b[39m     interrupt_after=interrupt_after,\n\u001b[32m   1620\u001b[39m     debug=debug,\n\u001b[32m   1621\u001b[39m     **kwargs,\n\u001b[32m   1622\u001b[39m ):\n\u001b[32m   1623\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m stream_mode == \u001b[33m\"\u001b[39m\u001b[33mvalues\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m   1624\u001b[39m         latest = chunk\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/__init__.py:1502\u001b[39m, in \u001b[36mPregel.astream\u001b[39m\u001b[34m(self, input, config, stream_mode, output_keys, interrupt_before, interrupt_after, debug, subgraphs)\u001b[39m\n\u001b[32m   1491\u001b[39m \u001b[38;5;66;03m# Similarly to Bulk Synchronous Parallel / Pregel model\u001b[39;00m\n\u001b[32m   1492\u001b[39m \u001b[38;5;66;03m# computation proceeds in steps, while there are channel updates\u001b[39;00m\n\u001b[32m   1493\u001b[39m \u001b[38;5;66;03m# channel updates from step N are only visible in step N+1\u001b[39;00m\n\u001b[32m   1494\u001b[39m \u001b[38;5;66;03m# channels are guaranteed to be immutable for the duration of the step,\u001b[39;00m\n\u001b[32m   1495\u001b[39m \u001b[38;5;66;03m# with channel updates applied only at the transition between steps\u001b[39;00m\n\u001b[32m   1496\u001b[39m \u001b[38;5;28;01mwhile\u001b[39;00m loop.tick(\n\u001b[32m   1497\u001b[39m     input_keys=\u001b[38;5;28mself\u001b[39m.input_channels,\n\u001b[32m   1498\u001b[39m     interrupt_before=interrupt_before_,\n\u001b[32m   1499\u001b[39m     interrupt_after=interrupt_after_,\n\u001b[32m   1500\u001b[39m     manager=run_manager,\n\u001b[32m   1501\u001b[39m ):\n\u001b[32m-> \u001b[39m\u001b[32m1502\u001b[39m     \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mfor\u001b[39;00m _ \u001b[38;5;129;01min\u001b[39;00m runner.atick(\n\u001b[32m   1503\u001b[39m         loop.tasks.values(),\n\u001b[32m   1504\u001b[39m         timeout=\u001b[38;5;28mself\u001b[39m.step_timeout,\n\u001b[32m   1505\u001b[39m         retry_policy=\u001b[38;5;28mself\u001b[39m.retry_policy,\n\u001b[32m   1506\u001b[39m         get_waiter=get_waiter,\n\u001b[32m   1507\u001b[39m     ):\n\u001b[32m   1508\u001b[39m         \u001b[38;5;66;03m# emit output\u001b[39;00m\n\u001b[32m   1509\u001b[39m         \u001b[38;5;28;01mfor\u001b[39;00m o \u001b[38;5;129;01min\u001b[39;00m output():\n\u001b[32m   1510\u001b[39m             \u001b[38;5;28;01myield\u001b[39;00m o\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/runner.py:194\u001b[39m, in \u001b[36mPregelRunner.atick\u001b[39m\u001b[34m(self, tasks, reraise, timeout, retry_policy, get_waiter)\u001b[39m\n\u001b[32m    192\u001b[39m     fut.cancel()\n\u001b[32m    193\u001b[39m \u001b[38;5;66;03m# panic on failure or timeout\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m194\u001b[39m \u001b[43m_panic_or_proceed\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    195\u001b[39m \u001b[43m    \u001b[49m\u001b[43mall_futures\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtimeout_exc_cls\u001b[49m\u001b[43m=\u001b[49m\u001b[43masyncio\u001b[49m\u001b[43m.\u001b[49m\u001b[43mTimeoutError\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpanic\u001b[49m\u001b[43m=\u001b[49m\u001b[43mreraise\u001b[49m\n\u001b[32m    196\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/runner.py:273\u001b[39m, in \u001b[36m_panic_or_proceed\u001b[39m\u001b[34m(futs, timeout_exc_cls, panic)\u001b[39m\n\u001b[32m    271\u001b[39m \u001b[38;5;66;03m# raise the exception\u001b[39;00m\n\u001b[32m    272\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m panic:\n\u001b[32m--> \u001b[39m\u001b[32m273\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m exc\n\u001b[32m    274\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    275\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/pregel/retry.py:102\u001b[39m, in \u001b[36marun_with_retry\u001b[39m\u001b[34m(task, retry_policy, stream)\u001b[39m\n\u001b[32m    100\u001b[39m         \u001b[38;5;28;01mpass\u001b[39;00m\n\u001b[32m    101\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m102\u001b[39m     \u001b[38;5;28;01mawait\u001b[39;00m task.proc.ainvoke(task.input, config)\n\u001b[32m    103\u001b[39m \u001b[38;5;66;03m# if successful, end\u001b[39;00m\n\u001b[32m    104\u001b[39m \u001b[38;5;28;01mbreak\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/utils/runnable.py:452\u001b[39m, in \u001b[36mRunnableSeq.ainvoke\u001b[39m\u001b[34m(self, input, config, **kwargs)\u001b[39m\n\u001b[32m    450\u001b[39m     coro = step.ainvoke(\u001b[38;5;28minput\u001b[39m, config)\n\u001b[32m    451\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m ASYNCIO_ACCEPTS_CONTEXT:\n\u001b[32m--> \u001b[39m\u001b[32m452\u001b[39m     \u001b[38;5;28minput\u001b[39m = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(coro, context=context)\n\u001b[32m    453\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    454\u001b[39m     \u001b[38;5;28minput\u001b[39m = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(coro)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langgraph/utils/runnable.py:235\u001b[39m, in \u001b[36mRunnableCallable.ainvoke\u001b[39m\u001b[34m(self, input, config, **kwargs)\u001b[39m\n\u001b[32m    233\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m ASYNCIO_ACCEPTS_CONTEXT:\n\u001b[32m    234\u001b[39m     coro = cast(Coroutine[\u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;28;01mNone\u001b[39;00m, Any], \u001b[38;5;28mself\u001b[39m.afunc(\u001b[38;5;28minput\u001b[39m, **kwargs))\n\u001b[32m--> \u001b[39m\u001b[32m235\u001b[39m     ret = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(coro, context=context)\n\u001b[32m    236\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    237\u001b[39m     ret = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m.afunc(\u001b[38;5;28minput\u001b[39m, **kwargs)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langsmith/run_helpers.py:522\u001b[39m, in \u001b[36mtraceable.<locals>.decorator.<locals>.async_wrapper\u001b[39m\u001b[34m(langsmith_extra, *args, **kwargs)\u001b[39m\n\u001b[32m    517\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mBaseException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    518\u001b[39m     \u001b[38;5;66;03m# shield from cancellation, given we're catching all exceptions\u001b[39;00m\n\u001b[32m    519\u001b[39m     \u001b[38;5;28;01mawait\u001b[39;00m asyncio.shield(\n\u001b[32m    520\u001b[39m         aitertools.aio_to_thread(_on_run_end, run_container, error=e)\n\u001b[32m    521\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m522\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[32m    523\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m aitertools.aio_to_thread(\n\u001b[32m    524\u001b[39m     _on_run_end, run_container, outputs=function_result\n\u001b[32m    525\u001b[39m )\n\u001b[32m    526\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m function_result\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/langsmith/run_helpers.py:508\u001b[39m, in \u001b[36mtraceable.<locals>.decorator.<locals>.async_wrapper\u001b[39m\u001b[34m(langsmith_extra, *args, **kwargs)\u001b[39m\n\u001b[32m    506\u001b[39m fr_coro = func(*args, **kwargs)\n\u001b[32m    507\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m accepts_context:\n\u001b[32m--> \u001b[39m\u001b[32m508\u001b[39m     function_result = \u001b[38;5;28;01mawait\u001b[39;00m asyncio.create_task(  \u001b[38;5;66;03m# type: ignore[call-arg]\u001b[39;00m\n\u001b[32m    509\u001b[39m         fr_coro, context=run_container[\u001b[33m\"\u001b[39m\u001b[33mcontext\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m    510\u001b[39m     )\n\u001b[32m    511\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    512\u001b[39m     \u001b[38;5;66;03m# Python < 3.11\u001b[39;00m\n\u001b[32m    513\u001b[39m     \u001b[38;5;28;01mwith\u001b[39;00m tracing_context(\n\u001b[32m    514\u001b[39m         **get_tracing_context(run_container[\u001b[33m\"\u001b[39m\u001b[33mcontext\u001b[39m\u001b[33m\"\u001b[39m])\n\u001b[32m    515\u001b[39m     ):\n",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[17]\u001b[39m\u001b[32m, line 39\u001b[39m, in \u001b[36mmake_code_summary_node.<locals>.summarize_file_node\u001b[39m\u001b[34m(state)\u001b[39m\n\u001b[32m     23\u001b[39m messages = [{\n\u001b[32m     24\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mrole\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33muser\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     25\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mcontent\u001b[39m\u001b[33m\"\u001b[39m: code_summary_prompt(latest_code=latest_code, language=\u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[32m     26\u001b[39m }]\n\u001b[32m     29\u001b[39m request_payload = {\n\u001b[32m     30\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mgoogle/gemma-3-4b-it\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     31\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m: messages,\n\u001b[32m   (...)\u001b[39m\u001b[32m     35\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mstop\u001b[39m\u001b[33m\"\u001b[39m: [\u001b[33m'\u001b[39m\u001b[33m<|im_end|>\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m     36\u001b[39m }\n\u001b[32m---> \u001b[39m\u001b[32m39\u001b[39m response = \u001b[38;5;28;01mawait\u001b[39;00m client.chat.completions.create(**request_payload)\n\u001b[32m     40\u001b[39m summary = response.choices[\u001b[32m0\u001b[39m].message.content\n\u001b[32m     41\u001b[39m original_model = state.directory_dict[target_directory].files[target_filepath]\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py:2000\u001b[39m, in \u001b[36mAsyncCompletions.create\u001b[39m\u001b[34m(self, messages, model, audio, frequency_penalty, function_call, functions, logit_bias, logprobs, max_completion_tokens, max_tokens, metadata, modalities, n, parallel_tool_calls, prediction, presence_penalty, reasoning_effort, response_format, seed, service_tier, stop, store, stream, stream_options, temperature, tool_choice, tools, top_logprobs, top_p, user, web_search_options, extra_headers, extra_query, extra_body, timeout)\u001b[39m\n\u001b[32m   1957\u001b[39m \u001b[38;5;129m@required_args\u001b[39m([\u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m], [\u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mstream\u001b[39m\u001b[33m\"\u001b[39m])\n\u001b[32m   1958\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mcreate\u001b[39m(\n\u001b[32m   1959\u001b[39m     \u001b[38;5;28mself\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1997\u001b[39m     timeout: \u001b[38;5;28mfloat\u001b[39m | httpx.Timeout | \u001b[38;5;28;01mNone\u001b[39;00m | NotGiven = NOT_GIVEN,\n\u001b[32m   1998\u001b[39m ) -> ChatCompletion | AsyncStream[ChatCompletionChunk]:\n\u001b[32m   1999\u001b[39m     validate_response_format(response_format)\n\u001b[32m-> \u001b[39m\u001b[32m2000\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._post(\n\u001b[32m   2001\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m/chat/completions\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   2002\u001b[39m         body=\u001b[38;5;28;01mawait\u001b[39;00m async_maybe_transform(\n\u001b[32m   2003\u001b[39m             {\n\u001b[32m   2004\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmessages\u001b[39m\u001b[33m\"\u001b[39m: messages,\n\u001b[32m   2005\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmodel\u001b[39m\u001b[33m\"\u001b[39m: model,\n\u001b[32m   2006\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33maudio\u001b[39m\u001b[33m\"\u001b[39m: audio,\n\u001b[32m   2007\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mfrequency_penalty\u001b[39m\u001b[33m\"\u001b[39m: frequency_penalty,\n\u001b[32m   2008\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mfunction_call\u001b[39m\u001b[33m\"\u001b[39m: function_call,\n\u001b[32m   2009\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mfunctions\u001b[39m\u001b[33m\"\u001b[39m: functions,\n\u001b[32m   2010\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mlogit_bias\u001b[39m\u001b[33m\"\u001b[39m: logit_bias,\n\u001b[32m   2011\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mlogprobs\u001b[39m\u001b[33m\"\u001b[39m: logprobs,\n\u001b[32m   2012\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmax_completion_tokens\u001b[39m\u001b[33m\"\u001b[39m: max_completion_tokens,\n\u001b[32m   2013\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmax_tokens\u001b[39m\u001b[33m\"\u001b[39m: max_tokens,\n\u001b[32m   2014\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmetadata\u001b[39m\u001b[33m\"\u001b[39m: metadata,\n\u001b[32m   2015\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mmodalities\u001b[39m\u001b[33m\"\u001b[39m: modalities,\n\u001b[32m   2016\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mn\u001b[39m\u001b[33m\"\u001b[39m: n,\n\u001b[32m   2017\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mparallel_tool_calls\u001b[39m\u001b[33m\"\u001b[39m: parallel_tool_calls,\n\u001b[32m   2018\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mprediction\u001b[39m\u001b[33m\"\u001b[39m: prediction,\n\u001b[32m   2019\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mpresence_penalty\u001b[39m\u001b[33m\"\u001b[39m: presence_penalty,\n\u001b[32m   2020\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mreasoning_effort\u001b[39m\u001b[33m\"\u001b[39m: reasoning_effort,\n\u001b[32m   2021\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mresponse_format\u001b[39m\u001b[33m\"\u001b[39m: response_format,\n\u001b[32m   2022\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mseed\u001b[39m\u001b[33m\"\u001b[39m: seed,\n\u001b[32m   2023\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mservice_tier\u001b[39m\u001b[33m\"\u001b[39m: service_tier,\n\u001b[32m   2024\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstop\u001b[39m\u001b[33m\"\u001b[39m: stop,\n\u001b[32m   2025\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstore\u001b[39m\u001b[33m\"\u001b[39m: store,\n\u001b[32m   2026\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstream\u001b[39m\u001b[33m\"\u001b[39m: stream,\n\u001b[32m   2027\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mstream_options\u001b[39m\u001b[33m\"\u001b[39m: stream_options,\n\u001b[32m   2028\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtemperature\u001b[39m\u001b[33m\"\u001b[39m: temperature,\n\u001b[32m   2029\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtool_choice\u001b[39m\u001b[33m\"\u001b[39m: tool_choice,\n\u001b[32m   2030\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtools\u001b[39m\u001b[33m\"\u001b[39m: tools,\n\u001b[32m   2031\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtop_logprobs\u001b[39m\u001b[33m\"\u001b[39m: top_logprobs,\n\u001b[32m   2032\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mtop_p\u001b[39m\u001b[33m\"\u001b[39m: top_p,\n\u001b[32m   2033\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33muser\u001b[39m\u001b[33m\"\u001b[39m: user,\n\u001b[32m   2034\u001b[39m                 \u001b[33m\"\u001b[39m\u001b[33mweb_search_options\u001b[39m\u001b[33m\"\u001b[39m: web_search_options,\n\u001b[32m   2035\u001b[39m             },\n\u001b[32m   2036\u001b[39m             completion_create_params.CompletionCreateParams,\n\u001b[32m   2037\u001b[39m         ),\n\u001b[32m   2038\u001b[39m         options=make_request_options(\n\u001b[32m   2039\u001b[39m             extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout\n\u001b[32m   2040\u001b[39m         ),\n\u001b[32m   2041\u001b[39m         cast_to=ChatCompletion,\n\u001b[32m   2042\u001b[39m         stream=stream \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[32m   2043\u001b[39m         stream_cls=AsyncStream[ChatCompletionChunk],\n\u001b[32m   2044\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/_base_client.py:1767\u001b[39m, in \u001b[36mAsyncAPIClient.post\u001b[39m\u001b[34m(self, path, cast_to, body, files, options, stream, stream_cls)\u001b[39m\n\u001b[32m   1753\u001b[39m \u001b[38;5;28;01masync\u001b[39;00m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mpost\u001b[39m(\n\u001b[32m   1754\u001b[39m     \u001b[38;5;28mself\u001b[39m,\n\u001b[32m   1755\u001b[39m     path: \u001b[38;5;28mstr\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1762\u001b[39m     stream_cls: \u001b[38;5;28mtype\u001b[39m[_AsyncStreamT] | \u001b[38;5;28;01mNone\u001b[39;00m = \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m   1763\u001b[39m ) -> ResponseT | _AsyncStreamT:\n\u001b[32m   1764\u001b[39m     opts = FinalRequestOptions.construct(\n\u001b[32m   1765\u001b[39m         method=\u001b[33m\"\u001b[39m\u001b[33mpost\u001b[39m\u001b[33m\"\u001b[39m, url=path, json_data=body, files=\u001b[38;5;28;01mawait\u001b[39;00m async_to_httpx_files(files), **options\n\u001b[32m   1766\u001b[39m     )\n\u001b[32m-> \u001b[39m\u001b[32m1767\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m.request(cast_to, opts, stream=stream, stream_cls=stream_cls)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/_base_client.py:1461\u001b[39m, in \u001b[36mAsyncAPIClient.request\u001b[39m\u001b[34m(self, cast_to, options, stream, stream_cls, remaining_retries)\u001b[39m\n\u001b[32m   1458\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1459\u001b[39m     retries_taken = \u001b[32m0\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m1461\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._request(\n\u001b[32m   1462\u001b[39m     cast_to=cast_to,\n\u001b[32m   1463\u001b[39m     options=options,\n\u001b[32m   1464\u001b[39m     stream=stream,\n\u001b[32m   1465\u001b[39m     stream_cls=stream_cls,\n\u001b[32m   1466\u001b[39m     retries_taken=retries_taken,\n\u001b[32m   1467\u001b[39m )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m/opt/anaconda3/envs/Deeplearning/lib/python3.11/site-packages/openai/_base_client.py:1562\u001b[39m, in \u001b[36mAsyncAPIClient._request\u001b[39m\u001b[34m(self, cast_to, options, stream, stream_cls, retries_taken)\u001b[39m\n\u001b[32m   1559\u001b[39m         \u001b[38;5;28;01mawait\u001b[39;00m err.response.aread()\n\u001b[32m   1561\u001b[39m     log.debug(\u001b[33m\"\u001b[39m\u001b[33mRe-raising status error\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m-> \u001b[39m\u001b[32m1562\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;28mself\u001b[39m._make_status_error_from_response(err.response) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m   1564\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._process_response(\n\u001b[32m   1565\u001b[39m     cast_to=cast_to,\n\u001b[32m   1566\u001b[39m     options=options,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1570\u001b[39m     retries_taken=retries_taken,\n\u001b[32m   1571\u001b[39m )\n",
+      "\u001b[31mNotFoundError\u001b[39m: Error code: 404 - {'error': 'Not Found'}"
+     ]
+    }
+   ],
+   "source": [
+    "result = await graph.ainvoke(input_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- 사용 기술 스택: Python 3.10, pip, uvicorn, alembic\n",
+      "- 주요 기능: Docker 이미지 빌드, 종속성 설치, 애플리케이션 코드 복사, 환경 변수 설정, 포트 노출, FastAPI 애플리케이션 실행 (알엠베이스 업그레이드 및 uvicorn 실행)\n",
+      "- 프로젝트 내 역할: FastAPI 애플리케이션을 실행하는 Docker 컨테이너 이미지 정의\n",
+      "- 변경 내용 요약:\n",
+      "    - `CMD` 명령어가 삭제되어 `CMD alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000`으로 변경됨.\n",
+      "    - 환경 변수 `DATABASE_URL`을 `.env` 파일에 저장하는 로직이 추가됨.\n",
+      "\n",
+      "====================================================================================================\n",
+      "- 사용 기술 스택: Python, FastAPI, Uvicorn, Alembic, Pytest, Coverage, MyPy, Pylint, Pyright\n",
+      "- 주요 기능:\n",
+      "    - 가상환경 관리 (venv, .venv)\n",
+      "    - 컴파일된 Python 파일 및 캐시 관리 (__pycache__, *.pyc, *.pyo, *.pyd)\n",
+      "    - 환경 변수 관리 (.env, *.env)\n",
+      "    - 로그 파일 관리 (*.log)\n",
+      "    - 데이터베이스 파일 관리 (*.sqlite3)\n",
+      "    - 프로젝트 인스턴스 폴더 관리 (instance/)\n",
+      "    - IDE 설정 관리 (.vscode/, .idea/, *.iml)\n",
+      "    - Jupyter Notebook 체크포인트 관리 (.ipynb_checkpoints/)\n",
+      "    - OS별 불필요 파일 관리 (.DS_Store, Thumbs.db)\n",
+      "    - FastAPI 및 Uvicorn 실행 관련 파일 관리 (*.pid, *.sock)\n",
+      "    - Docker 설정 관리 (docker-compose.override.yml)\n",
+      "    - 테스트 관련 파일 관리 (.coverage, pytest_cache/, htmlcov/)\n",
+      "    - Linting 관련 파일 관리 (.mypy_cache/, .pylint.d/, .pytest_cache/, .pyrightcache/)\n",
+      "- 변경 내용 요약:\n",
+      "    - alembic.ini 파일 삭제\n",
+      "    - alembic/versions/__pycache__ 폴더 삭제\n",
+      "\n",
+      "====================================================================================================\n",
+      "- 사용 기술 스택: Python, SQLAlchemy, Alembic\n",
+      "- 주요 기능: Alembic 설정 파일, 데이터베이스 연결 정보, 마이그레이션 설정, 포스트 쓰기 훅 설정, 로깅 설정\n",
+      "- 프로젝트 내 역할: 데이터베이스 마이그레이션 및 관리 설정을 담당\n",
+      "- 변경 내용 요약:\n",
+      "    - Alembic 설정 파일에 대한 다양한 옵션 설정 추가 (스크립트 위치, 파일 템플릿, 시스템 경로 추가, 타임존 설정, 슬러그 길이 제한, 자동 실행 여부, 버전 위치 지정, 버전 경로 구분자 설정, 재귀 검색 여부, 출력 인코딩 설정)\n",
+      "    - 포스트 쓰기 훅 설정 추가 (black, ruff 사용)\n",
+      "    - 로깅 설정 추가 (logger, handler, formatter 정의)\n",
+      "====================================================================================================\n",
+      "- 사용 기술 스택: Python, FastAPI, CORSMiddleware\n",
+      "- 주요 기능:\n",
+      "    - FastAPI 애플리케이션 생성\n",
+      "    - CORS 미들웨어 설정\n",
+      "    - 루트 경로(\"/\")에 대한 GET 요청 처리\n",
+      "    - 건강 상태 확인(\"/health\")에 대한 GET 요청 처리\n",
+      "    - Post 라우터(\"/posts\") 등록\n",
+      "- 프로젝트 내 역할: API 서버의 핵심 로직 및 라우팅 처리\n",
+      "- 변경 내용 요약:\n",
+      "    - CORS 미들웨어를 추가하여 프론트엔드에서 API 호출 가능하도록 설정\n",
+      "    - Vite 프론트엔드 URL을 CORS 설정에 추가\n",
+      "    - 모든 HTTP 메서드와 헤더를 허용하도록 CORS 설정\n",
+      "    - Post 라우터가 \"/posts\" 접두사로 등록되도록 설정\n",
+      "====================================================================================================\n",
+      "- 사용 기술 스택: Python, SQLAlchemy, Alembic\n",
+      "- 주요 기능: `upgrade` 함수는 `posts` 테이블에 `author` 컬럼을 추가하고, `downgrade` 함수는 `posts` 테이블에서 `author` 컬럼을 삭제합니다.\n",
+      "- 프로젝트 내 역할: 이 파일은 Alembic 마이그레이션 스크립트를 통해 데이터베이스 스키마를 변경하는 역할을 합니다.\n",
+      "- 변경 내용 요약:\n",
+      "    - `upgrade` 함수에 `posts` 테이블에 `author` 컬럼을 추가하는 명령이 추가되었습니다.\n",
+      "    - `downgrade` 함수에 `posts` 테이블에서 `author` 컬럼을 삭제하는 명령이 추가되었습니다.\n",
+      "====================================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "for dir_name, grouped_model in result[\"directory_dict\"].items():\n",
+    "    for file_name, file in grouped_model.files.items():\n",
+    "        print(file.code_summary)\n",
+    "        print(\"=\"*100)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n"
+     ]
+    }
+   ],
+   "source": [
+    "for filename, data in result[\"directory_dict\"].items():\n",
+    "    for file in data.files:\n",
+    "        print(data.files[file].file_node_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# 📅 2025-03-11 TIL\n",
+      "\n",
+      "### 📖 1. 오늘 배운 내용\n",
+      "오늘 분석한 코드 변경 이력은 `posts` 테이블에 `author` 컬럼을 추가하고 삭제하는 기능을 구현한 Alembic 마이그레이션 스크립트입니다. `alembic/versions` 디렉토리 내의 `upgrade` 및 `downgrade` 함수가 핵심 역할을 수행합니다. `upgrade` 함수는 새로운 스키마를 적용하고, `downgrade` 함수는 이전 스키마로 되돌립니다.\n",
+      "\n",
+      "### 📚 2. 개념 정리\n",
+      "Alembic은 Python 프로젝트에서 데이터베이스 스키마 변경을 관리하는 도구입니다. 마이그레이션 스크립트는 데이터베이스 변경 사항을 추적하고, 변경 사항을 안전하게 적용하거나 되돌릴 수 있도록 합니다. `upgrade` 함수는 새로운 마이그레이션을 적용하고, `downgrade` 함수는 이전 마이그레이션을 취소합니다. SQLAlchemy는 Alembic에서 사용하는 객체 관계 매핑(ORM) 라이브러리입니다.\n",
+      "\n",
+      "### 🤔 3. 해당 개념이 필요한 이유\n",
+      "데이터베이스 스키마는 애플리케이션의 핵심 데이터 구조를 정의합니다. 애플리케이션이 발전함에 따라 데이터베이스 스키마도 변경될 수 있습니다. Alembic을 사용하면 이러한 변경 사항을 체계적으로 관리하고, 데이터 손실이나 데이터 불일치 문제를 방지할 수 있습니다. 또한, 변경 사항을 쉽게 되돌릴 수 있어 개발 생산성을 높일 수 있습니다.\n",
+      "\n",
+      "### 💡 4. 개념을 활용하는 방법\n",
+      "Alembic을 활용하려면 먼저 Alembic을 프로젝트에 설치하고, 마이그레이션 파일을 생성해야 합니다. 마이그레이션 파일에는 데이터베이스 스키마 변경 사항이 정의됩니다. `upgrade` 함수는 새로운 스키마를 적용하고, `downgrade` 함수는 이전 스키마로 되돌립니다. Alembic은 마이그레이션 파일을 자동으로 실행하여 데이터베이스 스키마를 업데이트합니다.\n",
+      "\n",
+      "### 🛠️ 5. 문제 해결 과정\n",
+      "이 코드 분석을 통해 `posts` 테이블에 `author` 컬럼을 추가하고 삭제하는 기능이 구현되었다는 것을 알 수 있습니다.  `upgrade` 함수는 `author` 컬럼을 추가하고, `downgrade` 함수는 `author` 컬럼을 삭제하는 SQL 명령어를 포함합니다.  `directory_summary`는 사용 기술 스택 (Python, SQLAlchemy, Alembic)과 주요 기능을 명시하고 있습니다.  시스템 내 역할은 데이터베이스 스키마 변경을 위한 Alembic 마이그레이션 스크립트임을 나타냅니다. 변경 목적 요약은 `posts` 테이블에 `author` 컬럼을 추가하고 삭제하는 기능을 구현했다는 점을 강조합니다.\n",
+      "\n",
+      "### ✍️ 6. 하루 회고\n",
+      "Alembic을 사용하여 데이터베이스 스키마 변경을 관리하는 방법을 다시 한번 확인했습니다.  Alembic은 데이터베이스 변경 관리를 위한 강력한 도구이며, 프로젝트의 안정성과 유지보수성을 높이는 데 도움이 됩니다.  특히, 데이터베이스 스키마 변경이 빈번하게 발생하는 프로젝트에서는 Alembic을 사용하는 것이 좋습니다.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result[\"til_content\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Deeplearning",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Til/vLLM-server/triton_data/tests/__init__.py
+++ b/Til/vLLM-server/triton_data/tests/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Til/vLLM-server/triton_data/tests/conftest.py
+++ b/Til/vLLM-server/triton_data/tests/conftest.py
@@ -1,0 +1,182 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from tests.utils import OpenAIServer, setup_fastapi_app, setup_server
+
+
+### TEST ENVIRONMENT SETUP ###
+def infer_test_environment(tool_call_parser):
+    # Infer the test environment for simplicity in local dev/testing.
+    try:
+        import vllm as _
+
+        backend = "vllm"
+        if tool_call_parser == "mistral":
+            model = "mistral-nemo-instruct-2407"
+        else:
+            model = "llama-3.1-8b-instruct"
+        return backend, model
+    except ImportError:
+        print("No vllm installation found.")
+
+    try:
+        import tensorrt_llm as _
+
+        backend = "tensorrtllm"
+        model = "tensorrt_llm_bls"
+        return backend, model
+    except ImportError:
+        print("No tensorrt_llm installation found.")
+
+    raise Exception("Unknown test environment")
+
+
+def infer_test_model_repository(backend, tool_call_parser):
+    if tool_call_parser == "mistral":
+        model_repository = str(Path(__file__).parent / f"{backend}_mistral_models")
+    else:
+        model_repository = str(Path(__file__).parent / f"{backend}_models")
+    return model_repository
+
+
+# TODO: Refactor away from global variables
+TEST_MODEL = os.environ.get("TEST_MODEL")
+TEST_BACKEND = os.environ.get("TEST_BACKEND")
+TEST_MODEL_REPOSITORY = os.environ.get("TEST_MODEL_REPOSITORY")
+
+TEST_TOKENIZER = os.environ.get(
+    "TEST_TOKENIZER", "meta-llama/Meta-Llama-3.1-8B-Instruct"
+)
+TEST_TOOL_CALL_PARSER = os.environ.get("TEST_TOOL_CALL_PARSER", "llama3")
+TEST_PROMPT = "What is machine learning?"
+TEST_MESSAGES = [{"role": "user", "content": TEST_PROMPT}]
+
+if not TEST_BACKEND or not TEST_MODEL:
+    TEST_BACKEND, TEST_MODEL = infer_test_environment(TEST_TOOL_CALL_PARSER)
+
+if not TEST_MODEL_REPOSITORY:
+    TEST_MODEL_REPOSITORY = infer_test_model_repository(
+        TEST_BACKEND, TEST_TOOL_CALL_PARSER
+    )
+
+
+# NOTE: OpenAI client requires actual server running, and won't work
+# with the FastAPI TestClient. Run the server at module scope to run
+# only once for all the tests below.
+@pytest.fixture(scope="module")
+def server():
+    args = [
+        "--model-repository",
+        TEST_MODEL_REPOSITORY,
+        "--tokenizer",
+        TEST_TOKENIZER,
+        "--backend",
+        TEST_BACKEND,
+        "--tool-call-parser",
+        TEST_TOOL_CALL_PARSER,
+    ]
+    # TODO: Incorporate kserve frontend binding smoke tests to catch any
+    # breakage with default values or slight cli arg variations
+    extra_args = ["--enable-kserve-frontends"]
+    args += extra_args
+
+    with OpenAIServer(args) as openai_server:
+        yield openai_server
+
+
+# NOTE: The FastAPI TestClient acts like a server and triggers the FastAPI app
+# lifespan startup/shutdown, but does not actually expose the network port to interact
+# with arbitrary clients - you must use the TestClient returned to interact with
+# the "server" when "starting the server" via TestClient.
+@pytest.fixture(scope="class")
+def fastapi_client_class_scope():
+    server = setup_server(model_repository=TEST_MODEL_REPOSITORY)
+    app = setup_fastapi_app(
+        tokenizer=TEST_TOKENIZER, server=server, backend=TEST_BACKEND
+    )
+    with TestClient(app) as test_client:
+        yield test_client
+
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def model_repository():
+    return TEST_MODEL_REPOSITORY
+
+
+@pytest.fixture(scope="module")
+def model():
+    return TEST_MODEL
+
+
+@pytest.fixture(scope="module")
+def backend():
+    return TEST_BACKEND
+
+
+@pytest.fixture(scope="module")
+def tokenizer_model():
+    return TEST_TOKENIZER
+
+
+@pytest.fixture(scope="module")
+def prompt():
+    return TEST_PROMPT
+
+
+@pytest.fixture(scope="module")
+def messages():
+    return TEST_MESSAGES
+
+
+# FIXME: In TRTLLM tests, the in-process Triton server for the FastAPI app
+# does not automatically release GPU memory, even after calling stop().
+# The memory is only released when the entire pytest process exits.
+#
+# As a result, when the OpenAI server starts another Triton server as a subprocess,
+# there may not be enough GPU memory available to launch a new model instance.
+#
+# This is a workaround to ensure that tests using the OpenAI server run first.
+# Once the OpenAI server subprocess is terminated, tests using the FastAPI app can safely run.
+def pytest_collection_modifyitems(session, config, items):
+    def get_priority(item):
+        cls = item.cls
+        if cls:
+            if getattr(cls, "pytestmark", None):
+                for mark in cls.pytestmark:
+                    if mark.name == "openai":
+                        return 0
+                    elif mark.name == "fastapi":
+                        return 1
+        return 2  # unmarked tests last
+
+    items.sort(key=get_priority)

--- a/Til/vLLM-server/triton_data/tests/test_chat_completions.py
+++ b/Til/vLLM-server/triton_data/tests/test_chat_completions.py
@@ -1,0 +1,623 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import copy
+import subprocess
+from pathlib import Path
+from typing import List
+
+import pytest
+import tritonserver
+from fastapi.testclient import TestClient
+from tests.utils import setup_fastapi_app, setup_server
+
+
+@pytest.mark.fastapi
+class TestChatCompletions:
+    @pytest.fixture(scope="class")
+    def client(self, fastapi_client_class_scope):
+        yield fastapi_client_class_scope
+
+    def test_chat_completions_defaults(self, client, model: str, messages: List[dict]):
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": model, "messages": messages},
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+        # "usage" currently not supported
+        assert not response.json()["usage"]
+
+    def test_chat_completions_system_prompt(self, client, model: str):
+        # NOTE: Currently just sanity check that there are no issues when a
+        # system role is provided. There is no test logic to measure the quality
+        # of the response yet.
+        messages = [
+            {"role": "system", "content": "You are a Triton Inference Server expert."},
+            {"role": "user", "content": "What is machine learning?"},
+        ]
+
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
+    def test_chat_completions_system_prompt_only(self, client, model: str):
+        # No user prompt provided
+        messages = [
+            {"role": "system", "content": "You are a Triton Inference Server expert."}
+        ]
+
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
+    def test_chat_completions_user_prompt_str(self, client, model: str):
+        # No system prompt provided
+        messages = [{"role": "user", "content": "What is machine learning?"}]
+
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
+    def test_chat_completions_user_prompt_dict(self, client, model: str):
+        # No system prompt provided
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "What is machine learning?"}],
+            }
+        ]
+
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
+    @pytest.mark.parametrize(
+        "param_key, param_value",
+        [
+            ("temperature", 0.7),
+            ("max_tokens", 10),
+            ("top_p", 0.9),
+            ("frequency_penalty", 0.5),
+            ("presence_penalty", 0.2),
+            ("n", 1),
+            # Single stop word as a string
+            ("stop", "."),
+            # List of stop words
+            ("stop", []),
+            ("stop", [".", ","]),
+            # logprobs is a boolean for chat completions
+            ("logprobs", True),
+            ("logit_bias", {"0": 0}),
+            # NOTE: Extensions to the spec
+            ("min_tokens", 16),
+            ("ignore_eos", True),
+        ],
+    )
+    def test_chat_completions_sampling_parameters(
+        self, client, param_key, param_value, model: str, messages: List[dict]
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": messages,
+                param_key: param_value,
+            },
+        )
+
+        # FIXME: Add support and remove this check
+        unsupported_parameters = ["logprobs", "logit_bias"]
+        if param_key in unsupported_parameters:
+            assert response.status_code == 400
+            assert (
+                response.json()["detail"]
+                == "logit bias and log probs not currently supported"
+            )
+            return
+
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"]
+        assert response.json()["choices"][0]["message"]["role"] == "assistant"
+
+    @pytest.mark.parametrize(
+        "param_key, param_value",
+        [
+            ("temperature", 2.1),
+            ("temperature", -0.1),
+            ("max_tokens", -1),
+            ("top_p", 1.1),
+            ("frequency_penalty", 3),
+            ("frequency_penalty", -3),
+            ("presence_penalty", 2.1),
+            ("presence_penalty", -2.1),
+            # NOTE: Extensions to the spec
+            ("min_tokens", -1),
+            ("ignore_eos", 123),
+        ],
+    )
+    def test_chat_completions_invalid_sampling_parameters(
+        self, client, param_key, param_value, model: str, messages: List[dict]
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": messages,
+                param_key: param_value,
+            },
+        )
+        print("Response:", response.json())
+
+        # Assert schema validation error
+        assert response.status_code == 422
+
+    # Simple tests to verify max_tokens roughly behaves as expected
+    def test_chat_completions_max_tokens(
+        self, client, model: str, messages: List[dict]
+    ):
+        responses = []
+        payload = {"model": model, "messages": messages, "max_tokens": 1}
+
+        # Send two requests with max_tokens = 1 to check their similarity
+        payload["max_tokens"] = 1
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload,
+            )
+        )
+        # Send one requests with larger max_tokens to check its dis-similarity
+        payload["max_tokens"] = 100
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = (
+            responses[0].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response2_text = (
+            responses[1].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response3_text = (
+            responses[2].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        # Simplification: One token shouldn't be more than one space-delimited word
+        assert len(response1_text) == len(response2_text) == 1
+        assert len(response3_text) > len(response1_text)
+
+    @pytest.mark.parametrize(
+        "temperature",
+        [0.0, 1.0],
+    )
+    # Simple tests to verify temperature roughly behaves as expected
+    def test_chat_completions_temperature_vllm(
+        self, client, temperature, backend: str, model: str, messages: List[dict]
+    ):
+        if backend != "vllm":
+            pytest.skip(reason="Only used to test vLLM-specific temperature behavior")
+
+        responses = []
+        payload = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": 256,
+            "temperature": temperature,
+        }
+
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = (
+            responses[0].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response2_text = (
+            responses[1].json()["choices"][0]["message"]["content"].strip().split()
+        )
+
+        # Temperature of 0.0 indicates greedy sampling, so check
+        # that two equivalent requests produce the same response.
+        if temperature == 0.0:
+            # NOTE: This check may be ambitious to get an exact match in all
+            # cases depending on how other parameter defaults are set, so
+            # it can probably be removed if it introduces flakiness.
+            assert response1_text == response2_text
+        # Temperature of 1.0 indicates maximum randomness, so check
+        # that two equivalent requests produce different responses.
+        elif temperature == 1.0:
+            assert response1_text != response2_text
+        # Don't bother checking values other than the extremes
+        else:
+            raise ValueError(f"Unexpected {temperature=} for this test.")
+
+    # Remove xfail when fix is released and this test returns xpass status
+    @pytest.mark.xfail(
+        reason="TRT-LLM BLS model will ignore temperature until a later release"
+    )
+    # Simple tests to verify temperature roughly behaves as expected
+    def test_chat_completions_temperature_tensorrtllm(
+        self, client, backend: str, model: str, messages: List[dict]
+    ):
+        if backend != "tensorrtllm":
+            pytest.skip(
+                reason="Only used to test TRT-LLM-specific temperature behavior"
+            )
+
+        responses = []
+        payload1 = {
+            "model": model,
+            "messages": messages,
+            # Increase token length to allow more room for variability
+            "max_tokens": 200,
+            "temperature": 0.0,
+            # TRT-LLM requires certain settings of `top_k` / `top_p` to
+            # respect changes in `temperature`
+            "top_p": 0.5,
+        }
+
+        payload2 = copy.deepcopy(payload1)
+        payload2["temperature"] = 1.0
+
+        # First 2 responses should be the same in TRT-LLM with identical payload
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload1,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload1,
+            )
+        )
+        # Third response should differ with different temperature in payload
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload2,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = (
+            responses[0].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response2_text = (
+            responses[1].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response3_text = (
+            responses[2].json()["choices"][0]["message"]["content"].strip().split()
+        )
+
+        assert response1_text == response2_text
+        assert response1_text != response3_text
+
+    # Simple tests to verify random seed roughly behaves as expected
+    def test_chat_completions_seed(self, client, model: str, messages: List[dict]):
+        responses = []
+        payload1 = {
+            "model": model,
+            "messages": messages,
+            # Increase token length to allow more room for variability
+            "max_tokens": 200,
+            "seed": 1,
+        }
+        payload2 = copy.deepcopy(payload1)
+        payload2["seed"] = 2
+
+        # First 2 responses should be the same in both vLLM and TRT-LLM with identical seed
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload1,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload1,
+            )
+        )
+        # Third response should differ with different seed in payload
+        responses.append(
+            client.post(
+                "/v1/chat/completions",
+                json=payload2,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = (
+            responses[0].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response2_text = (
+            responses[1].json()["choices"][0]["message"]["content"].strip().split()
+        )
+        response3_text = (
+            responses[2].json()["choices"][0]["message"]["content"].strip().split()
+        )
+
+        assert response1_text == response2_text
+        assert response1_text != response3_text
+
+    def test_chat_completions_no_message(
+        self, client, model: str, messages: List[dict]
+    ):
+        # Message validation requires min_length of 1
+        messages = []
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "List should have at least 1 item after validation, not 0"
+        )
+
+    def test_chat_completions_empty_message(
+        self, client, model: str, messages: List[dict]
+    ):
+        # Message validation requires min_length of 1
+        messages = [{}]
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["msg"] == "Field required"
+
+    def test_chat_completions_multiple_choices(
+        self, client, model: str, messages: List[dict]
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": model, "messages": messages, "n": 2},
+        )
+
+        assert response.status_code == 400
+        assert "only single choice" in response.json()["detail"]
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_chat_completions_streaming(self, client):
+        pass
+
+    def test_chat_completions_no_streaming(
+        self, client, model: str, messages: List[dict]
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": model, "messages": messages, "stream": False},
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_function_calling(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_lora(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_multi_lora(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_request_n_choices(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_request_logprobs(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_request_logit_bias(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_usage_response(self):
+        pass
+
+
+# For tests that won't use the same pytest fixture for server startup across
+# the whole class test suite.
+@pytest.mark.fastapi
+class TestChatCompletionsTokenizers:
+    # Re-use a single Triton server for different frontend configurations
+    @pytest.fixture(scope="class")
+    def server(self, model_repository: str):
+        server = setup_server(model_repository)
+        yield server
+        server.stop()
+
+    # A tokenizer must be known for /chat/completions endpoint in order to
+    # apply chat templates, and for simplicity in determination, users should
+    # define the tokenizer. So, explicitly raise an error if none is provided.
+    def test_chat_completions_no_tokenizer(
+        self,
+        server: tritonserver.Server,
+        backend: str,
+        model: str,
+        messages: List[dict],
+    ):
+        app = setup_fastapi_app(tokenizer="", server=server, backend=backend)
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/chat/completions",
+                json={"model": model, "messages": messages},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Unknown tokenizer"
+
+    def test_chat_completions_custom_tokenizer(
+        self,
+        server: tritonserver.Server,
+        backend: str,
+        tokenizer_model: str,
+        model: str,
+        messages: List[dict],
+    ):
+        # Tokenizers can be provided by a local file path to a directory containing
+        # the relevant files such as tokenizer.json and tokenizer_config.json.
+        custom_tokenizer_path = str(Path(__file__).parent / "custom_tokenizer")
+        download_cmd = f"huggingface-cli download --local-dir {custom_tokenizer_path} {tokenizer_model} --include *.json"
+        print(f"Running download command: {download_cmd}")
+        subprocess.run(download_cmd.split(), check=True)
+
+        # Compare the downloaded tokenizer response against remote HF equivalent
+        # to assert equivalent functionality in responses and chat template.
+        app_local = setup_fastapi_app(
+            tokenizer=custom_tokenizer_path, server=server, backend=backend
+        )
+        app_hf = setup_fastapi_app(
+            tokenizer=tokenizer_model, server=server, backend=backend
+        )
+
+        responses = []
+        with TestClient(app_local) as client_local, TestClient(app_hf) as client_hf:
+            payload = {"model": model, "messages": messages, "temperature": 0}
+            responses.append(client_local.post("/v1/chat/completions", json=payload))
+            responses.append(client_hf.post("/v1/chat/completions", json=payload))
+
+        for response in responses:
+            assert response.status_code == 200
+            message = response.json()["choices"][0]["message"]
+            assert message["content"].strip()
+            assert message["role"] == "assistant"
+
+        def equal_dicts(d1, d2, ignore_keys):
+            d1_filtered = {k: v for k, v in d1.items() if k not in ignore_keys}
+            d2_filtered = {k: v for k, v in d2.items() if k not in ignore_keys}
+            return d1_filtered == d2_filtered
+
+        ignore_keys = ["id", "created"]
+        assert equal_dicts(
+            responses[0].json(), responses[1].json(), ignore_keys=ignore_keys
+        )
+
+    def test_chat_completions_invalid_chat_tokenizer(
+        self,
+        server: tritonserver.Server,
+        backend: str,
+        model: str,
+        messages: List[dict],
+    ):
+        # NOTE: Use of apply_chat_template on a tokenizer that doesn't support it
+        # is a warning prior to transformers 4.44, and an error afterwards.
+        # NOTE: Can remove after both TRT-LLM and VLLM containers have this version.
+        import transformers
+
+        print(f"{transformers.__version__=}")
+        if transformers.__version__ < "4.44.0":
+            pytest.xfail()
+
+        # Pick a tokenizer with no chat template defined
+        invalid_chat_tokenizer = "gpt2"
+        try:
+            app = setup_fastapi_app(
+                tokenizer=invalid_chat_tokenizer, server=server, backend=backend
+            )
+        except OSError as e:
+            expected_msg = f"We couldn't connect to 'https://huggingface.co' to load this file, couldn't find it in the cached files and it looks like {invalid_chat_tokenizer} is not the path to a directory containing a file named config.json."
+            if expected_msg in str(e):
+                pytest.skip("HuggingFace network issues")
+            raise e
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/chat/completions",
+                json={"model": model, "messages": messages},
+            )
+
+        assert response.status_code == 400
+        # Error may vary based on transformers version
+        expected_errors = [
+            "cannot use apply_chat_template()",
+            "cannot use chat template",
+        ]
+        assert any(
+            error in response.json()["detail"].lower() for error in expected_errors
+        )

--- a/Til/vLLM-server/triton_data/tests/test_completions.py
+++ b/Til/vLLM-server/triton_data/tests/test_completions.py
@@ -1,0 +1,372 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import copy
+
+import pytest
+
+
+@pytest.mark.fastapi
+class TestCompletions:
+    @pytest.fixture(scope="class")
+    def client(self, fastapi_client_class_scope):
+        yield fastapi_client_class_scope
+
+    def test_completions_defaults(self, client, model: str, prompt: str):
+        response = client.post(
+            "/v1/completions",
+            json={"model": model, "prompt": prompt},
+        )
+
+        print("Response:", response.json())
+        assert response.status_code == 200
+        # NOTE: Could be improved to look for certain quality of response,
+        #       or tested with dummy identity model.
+        assert response.json()["choices"][0]["text"].strip()
+        # "usage" currently not supported
+        assert not response.json()["usage"]
+
+    @pytest.mark.parametrize(
+        "sampling_parameter, value",
+        [
+            ("temperature", 0.7),
+            ("max_tokens", 10),
+            ("top_p", 0.9),
+            ("frequency_penalty", 0.5),
+            ("presence_penalty", 0.2),
+            ("best_of", 1),
+            ("n", 1),
+            # logprobs is an integer for completions
+            ("logprobs", 5),
+            ("logit_bias", {"0": 0}),
+            # NOTE: Extensions to the spec
+            ("min_tokens", 16),
+            ("ignore_eos", True),
+        ],
+    )
+    def test_completions_sampling_parameters(
+        self, client, sampling_parameter, value, model: str, prompt: str
+    ):
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": model,
+                "prompt": prompt,
+                sampling_parameter: value,
+            },
+        )
+        print("Response:", response.json())
+
+        # FIXME: Add support and remove this check
+        unsupported_parameters = ["logprobs", "logit_bias"]
+        if sampling_parameter in unsupported_parameters:
+            assert response.status_code == 400
+            assert response.json()["detail"] == "logit bias and log probs not supported"
+            return
+
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["text"].strip()
+
+    # Simple tests to verify max_tokens roughly behaves as expected
+    def test_completions_max_tokens(self, client, model: str, prompt: str):
+        responses = []
+        payload = {"model": model, "prompt": prompt, "max_tokens": 1}
+
+        # Send two requests with max_tokens = 1 to check their similarity
+        payload["max_tokens"] = 1
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload,
+            )
+        )
+        # Send one requests with larger max_tokens to check its dis-similarity
+        payload["max_tokens"] = 100
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = responses[0].json()["choices"][0]["text"].strip().split()
+        response2_text = responses[1].json()["choices"][0]["text"].strip().split()
+        response3_text = responses[2].json()["choices"][0]["text"].strip().split()
+        # Simplification: One token shouldn't be more than one space-delimited word
+        assert len(response1_text) == len(response2_text) == 1
+        assert len(response3_text) > len(response1_text)
+
+    @pytest.mark.parametrize(
+        "temperature",
+        [0.0, 1.0],
+    )
+    # Simple tests to verify temperature roughly behaves as expected
+    def test_completions_temperature_vllm(
+        self, client, temperature, backend: str, model: str, prompt: str
+    ):
+        if backend != "vllm":
+            pytest.skip(reason="Only used to test vLLM-specific temperature behavior")
+
+        responses = []
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "temperature": temperature,
+        }
+
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = responses[0].json()["choices"][0]["text"].strip().split()
+        response2_text = responses[1].json()["choices"][0]["text"].strip().split()
+
+        # Temperature of 0.0 indicates greedy sampling, so check
+        # that two equivalent requests produce the same response.
+        if temperature == 0.0:
+            # NOTE: This check may be ambitious to get an exact match in all
+            # frameworks depending on how other parameter defaults are set, so
+            # it can probably be removed if it introduces flakiness.
+            print(f"Comparing '{response1_text}' == '{response2_text}'")
+            assert response1_text == response2_text
+        # Temperature of 1.0 indicates maximum randomness, so check
+        # that two equivalent requests produce different responses.
+        elif temperature == 1.0:
+            print(f"Comparing '{response1_text}' != '{response2_text}'")
+            assert response1_text != response2_text
+        # Don't bother checking values other than the extremes
+        else:
+            raise ValueError(f"Unexpected {temperature=} for this test.")
+
+    # Remove xfail when fix is released and this test returns xpass status
+    @pytest.mark.xfail(
+        reason="TRT-LLM BLS model will ignore temperature until a later release"
+    )
+    # Simple tests to verify temperature roughly behaves as expected
+    def test_completions_temperature_tensorrtllm(
+        self, client, backend: str, model: str, prompt: str
+    ):
+        if backend != "tensorrtllm":
+            pytest.skip(reason="Only used to test vLLM-specific temperature behavior")
+
+        responses = []
+        payload1 = {
+            "model": model,
+            "prompt": prompt,
+            "temperature": 0.0,
+            # TRT-LLM requires certain settings of `top_k` / `top_p` to
+            # respect changes in `temperature`
+            "top_p": 0.5,
+        }
+        payload2 = copy.deepcopy(payload1)
+        payload2["temperature"] = 1.0
+
+        # First 2 responses should be the same in TRT-LLM with identical payload
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload1,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload1,
+            )
+        )
+        # Third response should differ with different temperature in payload
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload2,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = responses[0].json()["choices"][0]["text"].strip().split()
+        response2_text = responses[1].json()["choices"][0]["text"].strip().split()
+        response3_text = responses[2].json()["choices"][0]["text"].strip().split()
+
+        assert response1_text == response2_text
+        assert response1_text != response3_text
+
+    # Simple tests to verify seed roughly behaves as expected
+    def test_completions_seed(self, client, model: str, prompt: str):
+        responses = []
+        payload1 = {"model": model, "prompt": prompt, "seed": 1}
+        payload2 = copy.deepcopy(payload1)
+        payload2["seed"] = 2
+
+        # First 2 responses should be the same in TRT-LLM with identical payload
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload1,
+            )
+        )
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload1,
+            )
+        )
+        # Third response should differ with different temperature in payload
+        responses.append(
+            client.post(
+                "/v1/completions",
+                json=payload2,
+            )
+        )
+
+        for response in responses:
+            print("Response:", response.json())
+            assert response.status_code == 200
+
+        response1_text = responses[0].json()["choices"][0]["text"].strip().split()
+        response2_text = responses[1].json()["choices"][0]["text"].strip().split()
+        response3_text = responses[2].json()["choices"][0]["text"].strip().split()
+
+        assert response1_text == response2_text
+        assert response1_text != response3_text
+
+    @pytest.mark.parametrize(
+        "sampling_parameter, value",
+        [
+            ("temperature", 2.1),
+            ("temperature", -0.1),
+            ("max_tokens", -1),
+            ("top_p", 1.1),
+            ("frequency_penalty", 3),
+            ("frequency_penalty", -3),
+            ("presence_penalty", 2.1),
+            ("presence_penalty", -2.1),
+            # NOTE: Extensions to the spec
+            ("min_tokens", -1),
+            ("ignore_eos", 123),
+        ],
+    )
+    def test_completions_invalid_sampling_parameters(
+        self, client, sampling_parameter, value, model: str, prompt: str
+    ):
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": model,
+                "prompt": prompt,
+                sampling_parameter: value,
+            },
+        )
+
+        print("Response:", response.json())
+        assert response.status_code == 422
+
+    def test_completions_empty_request(self, client):
+        response = client.post("/v1/completions", json={})
+        assert response.status_code == 422
+
+    def test_completions_no_model(self, client, prompt: str):
+        response = client.post("/v1/completions", json={"prompt": prompt})
+        assert response.status_code == 422
+
+    def test_completions_no_prompt(self, client, model: str):
+        response = client.post("/v1/completions", json={"model": model})
+        assert response.status_code == 422
+
+    def test_completions_empty_prompt(self, client, model: str):
+        response = client.post("/v1/completions", json={"model": model, "prompt": ""})
+
+        # NOTE: Should this be validated in schema instead?
+        # 400 Error returned in route handler
+        assert response.status_code == 400
+
+    def test_no_prompt(self, client, model: str):
+        response = client.post("/v1/completions", json={"model": model})
+
+        # 422 Error returned by schema validation
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        "sampling_parameter_dict",
+        [
+            # Each individual parameter should fail for > 1 for now
+            {"n": 2},
+            {"best_of": 2},
+            {"n": 2, "best_of": 2},
+            # When individual params > 1 are supported, best_of < n should fail
+            {"n": 2, "best_of": 1},
+        ],
+    )
+    def test_completions_multiple_choices(
+        self, client, sampling_parameter_dict: dict, model: str, prompt: str
+    ):
+        response = client.post(
+            "/v1/completions",
+            json={"model": model, "prompt": prompt, **sampling_parameter_dict},
+        )
+        print("Response:", response.json())
+
+        # FIXME: Add support and test for success
+        # Expected to fail when n or best_of > 1, only single choice supported for now
+        assert response.status_code == 400
+        assert "only single choice" in response.json()["detail"]
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_lora(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_multi_lora(self):
+        pass
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_usage_response(self):
+        pass

--- a/Til/vLLM-server/triton_data/tests/test_lora.py
+++ b/Til/vLLM-server/triton_data/tests/test_lora.py
@@ -1,0 +1,353 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+import shutil
+import unittest
+
+from huggingface_hub import snapshot_download
+from openai import BadRequestError, NotFoundError
+
+from .utils import OpenAIServer
+
+
+def is_vllm_installed():
+    try:
+        import vllm as _
+
+        return True
+    except ImportError:
+        return False
+
+
+class LoRATest(unittest.TestCase):
+    _model_name = "gemma-2b"
+    # TODO: Find a LoRA model that has its own tokenizer.
+    _tokenizer = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    _lora_separator = "_lora_"
+    _prompt = "When was the wheel invented?"
+    # more prompts that may yield different outputs:
+    # - "Why can camels survive for long without water?"
+    # - "What is LAPR?"
+    # - "What is the difference between pets and cattle?"
+    _temperature = 0
+    _top_p = 1
+
+    def setUp(self):
+        self._completions_outputs = {}
+        self._chat_completion_outputs = {}
+
+    def _create_model_repository_with_lora(self):
+        shutil.rmtree("models", ignore_errors=True)
+        os.makedirs(f"models/{self._model_name}/1", exist_ok=True)
+        with open(f"models/{self._model_name}/config.pbtxt", "w") as f:
+            f.write('backend: "vllm"')
+        with open(f"models/{self._model_name}/1/model.json", "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "model": "unsloth/gemma-2b",
+                        "enable_lora": True,
+                        "max_lora_rank": 32,
+                    }
+                )
+            )
+        with open(f"models/{self._model_name}/1/multi_lora.json", "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "doll": f"models/{self._model_name}/1/GemmaDoll",
+                        "sheep": f"models/{self._model_name}/1/GemmaSheep",
+                    }
+                )
+            )
+        snapshot_download(
+            repo_id="swathijn/GemmaDoll-2b-dolly-LORA-Tune",
+            local_dir=f"models/{self._model_name}/1/GemmaDoll",
+        )
+        snapshot_download(
+            repo_id="eduardo-alvarez/GemmaSheep-2B-LORA-TUNED",
+            local_dir=f"models/{self._model_name}/1/GemmaSheep",
+        )
+
+    def _create_model_repository_without_lora(self):
+        shutil.rmtree("models", ignore_errors=True)
+        os.makedirs(f"models/{self._model_name}/1", exist_ok=True)
+        with open(f"models/{self._model_name}/config.pbtxt", "w") as f:
+            f.write('backend: "vllm"')
+        with open(f"models/{self._model_name}/1/model.json", "w") as f:
+            f.write(json.dumps({"model": "unsloth/gemma-2b"}))
+
+    def _create_model_repository_mock_llm(self):
+        shutil.rmtree("models", ignore_errors=True)
+        os.makedirs(f"models/{self._model_name}/1", exist_ok=True)
+        with open(f"models/{self._model_name}/config.pbtxt", "w") as f:
+            f.write(
+                """
+                backend: "python"
+                max_batch_size: 0
+                model_transaction_policy { decoupled: True }
+                input [
+                    {
+                        name: "text_input"
+                        data_type: TYPE_STRING
+                        dims: [ 1 ]
+                    },
+                    {
+                        name: "stream"
+                        data_type: TYPE_BOOL
+                        dims: [ 1 ]
+                    },
+                    {
+                        name: "sampling_parameters"
+                        data_type: TYPE_STRING
+                        dims: [ 1 ]
+                    },
+                    {
+                        name: "exclude_input_in_output"
+                        data_type: TYPE_BOOL
+                        dims: [ 1 ]
+                    }
+                ]
+                output [
+                    {
+                        name: "text_output"
+                        data_type: TYPE_STRING
+                        dims: [ -1 ]
+                    }
+                ]
+            """
+            )
+        shutil.copy(
+            "tests/test_models/mock_llm/1/model.py", f"models/{self._model_name}/1"
+        )
+
+    def _get_model_name(self, lora_name):
+        model_name = self._model_name
+        if lora_name != "":
+            model_name += f"{self._lora_separator}{lora_name}"
+        return model_name
+
+    def _test_list_models(self, client, expected_lora_names):
+        expected_model_names = []
+        for lora_name in expected_lora_names:
+            expected_model_names.append(self._get_model_name(lora_name))
+        models = client.models.list()
+        for model in models:
+            self.assertIn(model.id, expected_model_names)
+            expected_model_names.remove(model.id)
+        self.assertEqual(len(expected_model_names), 0)
+
+    def _test_retrieve_model(self, client, lora_name):
+        model_name = self._get_model_name(lora_name)
+        model = client.models.retrieve(model_name)
+        self.assertEqual(model.id, model_name)
+
+    def _test_completions(self, client, lora_name):
+        model_name = self._get_model_name(lora_name)
+        completion = client.completions.create(
+            model=model_name,
+            prompt=self._prompt,
+            temperature=self._temperature,
+            top_p=self._top_p,
+        )
+        self.assertEqual(completion.model, model_name)
+        output = completion.choices[0].text
+        for other_output in self._completions_outputs.values():
+            self.assertNotEqual(
+                output,
+                other_output,
+                msg=f"other completions outputs: {self._completions_outputs}",
+            )
+        self._completions_outputs[lora_name] = output
+
+    def _test_chat_completion(self, client, lora_name):
+        model_name = self._get_model_name(lora_name)
+        messages = [{"role": "user", "content": self._prompt}]
+        chat_completion = client.chat.completions.create(
+            model=model_name,
+            messages=messages,
+            temperature=self._temperature,
+            top_p=self._top_p,
+        )
+        self.assertEqual(chat_completion.model, model_name)
+        output = chat_completion.choices[0].message.content
+        for other_output in self._chat_completion_outputs.values():
+            self.assertNotEqual(
+                output,
+                other_output,
+                msg=f"other chat outputs: {self._chat_completion_outputs}",
+            )
+        self._chat_completion_outputs[lora_name] = output
+
+    @unittest.skipUnless(is_vllm_installed(), "vLLM not installed")
+    def test_lora_separator_not_set(self):
+        self._create_model_repository_with_lora()
+        with OpenAIServer(
+            cli_args=[
+                "--model-repository",
+                "models",
+                "--tokenizer",
+                self._tokenizer,
+            ],
+            env_dict={"CUDA_VISIBLE_DEVICES": "0"},
+        ) as server:
+            client = server.get_client()
+            # Test listing/retrieving models
+            self._test_list_models(client, [""])
+            self._test_retrieve_model(client, "")
+            with self.assertRaises(NotFoundError) as e:
+                self._test_retrieve_model(client, "doll")
+            expected_error = f"Error code: 404 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}doll'}}"
+            self.assertEqual(str(e.exception), expected_error)
+            with self.assertRaises(NotFoundError) as e:
+                self._test_retrieve_model(client, "sheep")
+            expected_error = f"Error code: 404 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}sheep'}}"
+            self.assertEqual(str(e.exception), expected_error)
+            # Test selecting LoRAs
+            self._test_completions(client, "")
+            self._test_chat_completion(client, "")
+            with self.assertRaises(BadRequestError) as e:
+                self._test_completions(client, "doll")
+            expected_error = f"Error code: 400 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}doll'}}"
+            self.assertEqual(str(e.exception), expected_error)
+            with self.assertRaises(BadRequestError) as e:
+                self._test_chat_completion(client, "sheep")
+            expected_error = f"Error code: 400 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}sheep'}}"
+            self.assertEqual(str(e.exception), expected_error)
+
+    @unittest.skipUnless(is_vllm_installed(), "vLLM not installed")
+    def test_lora_separator_set(self):
+        self._create_model_repository_with_lora()
+        with OpenAIServer(
+            cli_args=[
+                "--model-repository",
+                "models",
+                "--tokenizer",
+                self._tokenizer,
+                "--lora-separator",
+                self._lora_separator,
+            ],
+            env_dict={"CUDA_VISIBLE_DEVICES": "0"},
+        ) as server:
+            client = server.get_client()
+            # Test listing/retrieving models
+            self._test_list_models(client, ["", "doll", "sheep"])
+            self._test_retrieve_model(client, "")
+            self._test_retrieve_model(client, "doll")
+            self._test_retrieve_model(client, "sheep")
+            # Test retrieving LoRAs unknown to the backend
+            with self.assertRaises(NotFoundError) as e:
+                self._test_retrieve_model(client, "unknown")
+            expected_error = f"Error code: 404 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}unknown'}}"
+            self.assertEqual(str(e.exception), expected_error)
+            # Test selecting LoRAs
+            self._test_completions(client, "")
+            self._test_completions(client, "doll")
+            self._test_completions(client, "sheep")
+            self._test_chat_completion(client, "")
+            self._test_chat_completion(client, "doll")
+            self._test_chat_completion(client, "sheep")
+            # Test selecting LoRAs unknown to the backend
+            expected_error = f"Error code: 400 - {{'detail': 'Unknown LoRA: unknown; for model: {self._model_name}{self._lora_separator}unknown'}}"
+            with self.assertRaises(BadRequestError) as e:
+                self._test_completions(client, "unknown")
+            self.assertEqual(str(e.exception), expected_error)
+            with self.assertRaises(BadRequestError) as e:
+                self._test_chat_completion(client, "unknown")
+            self.assertEqual(str(e.exception), expected_error)
+
+    @unittest.skipUnless(is_vllm_installed(), "vLLM not installed")
+    def test_lora_separator_set_for_lora_off_model(self):
+        self._create_model_repository_without_lora()
+        with OpenAIServer(
+            cli_args=[
+                "--model-repository",
+                "models",
+                "--tokenizer",
+                self._tokenizer,
+                "--lora-separator",
+                self._lora_separator,
+            ],
+            env_dict={"CUDA_VISIBLE_DEVICES": "0"},
+        ) as server:
+            client = server.get_client()
+            # Test listing/retrieving models
+            self._test_list_models(client, [""])
+            self._test_retrieve_model(client, "")
+            # Test retrieving models with LoRAs
+            with self.assertRaises(NotFoundError) as e:
+                self._test_retrieve_model(client, "doll")
+            expected_error = f"Error code: 404 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}doll'}}"
+            self.assertEqual(str(e.exception), expected_error)
+            # Test inference
+            self._test_completions(client, "")
+            self._test_chat_completion(client, "")
+            # Test selecting LoRAs
+            expected_error = f"Error code: 400 - {{'detail': 'Unknown LoRA: sheep; for model: {self._model_name}{self._lora_separator}sheep'}}"
+            with self.assertRaises(BadRequestError) as e:
+                self._test_completions(client, "sheep")
+            self.assertEqual(str(e.exception), expected_error)
+            with self.assertRaises(BadRequestError) as e:
+                self._test_chat_completion(client, "sheep")
+            self.assertEqual(str(e.exception), expected_error)
+
+    @unittest.skipUnless(is_vllm_installed(), "vLLM not installed")
+    def test_lora_separator_set_for_non_vllm_formatted_models(self):
+        self._create_model_repository_mock_llm()
+        with OpenAIServer(
+            cli_args=[
+                "--model-repository",
+                "models",
+                "--tokenizer",
+                self._tokenizer,
+                "--backend",
+                "vllm",
+                "--lora-separator",
+                self._lora_separator,
+            ],
+            env_dict={"CUDA_VISIBLE_DEVICES": "0"},
+        ) as server:
+            client = server.get_client()
+            # Test listing/retrieving models
+            self._test_list_models(client, [""])
+            self._test_retrieve_model(client, "")
+            # Test retrieving models with LoRAs
+            with self.assertRaises(NotFoundError) as e:
+                self._test_retrieve_model(client, "sheep")
+            expected_error = f"Error code: 404 - {{'detail': 'Unknown model: {self._model_name}{self._lora_separator}sheep'}}"
+            self.assertEqual(str(e.exception), expected_error)
+            # Test selecting LoRAs
+            # Expectation:
+            #   If the frontend cannot determine which LoRA(s) are available, then any
+            #   request with a well-formed LoRA model name will be inferenced.
+            self._test_completions(client, "doll")
+            self._test_chat_completion(client, "doll")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Til/vLLM-server/triton_data/tests/test_models/identity_py/1/model.py
+++ b/Til/vLLM-server/triton_data/tests/test_models/identity_py/1/model.py
@@ -1,0 +1,40 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    def execute(self, requests):
+        """
+        Identity model in Python backend.
+        """
+        responses = []
+        for request in requests:
+            input_tensor = pb_utils.get_input_tensor_by_name(request, "INPUT0")
+            out_tensor = pb_utils.Tensor("OUTPUT0", input_tensor.as_numpy())
+            responses.append(pb_utils.InferenceResponse([out_tensor]))
+        return responses

--- a/Til/vLLM-server/triton_data/tests/test_models/identity_py/config.pbtxt
+++ b/Til/vLLM-server/triton_data/tests/test_models/identity_py/config.pbtxt
@@ -1,0 +1,51 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+backend: "python"
+max_batch_size: 64
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+instance_group [
+  {
+    count: 1
+    kind : KIND_CPU
+  }
+]

--- a/Til/vLLM-server/triton_data/tests/test_models/mock_llm/1/model.py
+++ b/Til/vLLM-server/triton_data/tests/test_models/mock_llm/1/model.py
@@ -1,0 +1,108 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import time
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    def initialize(self, args):
+        self.model_config = json.loads(args["model_config"])
+        self.decoupled = self.model_config.get("model_transaction_policy", {}).get(
+            "decoupled"
+        )
+
+    def execute(self, requests):
+        if self.decoupled:
+            return self.exec_decoupled(requests)
+        else:
+            return self.exec(requests)
+
+    def exec(self, requests):
+        responses = []
+        for request in requests:
+            params = json.loads(request.parameters())
+            rep_count = params["REPETITION"] if "REPETITION" in params else 1
+
+            input_np = pb_utils.get_input_tensor_by_name(
+                request, "text_intpu"
+            ).as_numpy()
+            stream_np = pb_utils.get_input_tensor_by_name(request, "stream").as_numpy()
+            stream = stream_np.flatten()[0]
+            if stream:
+                responses.append(
+                    pb_utils.InferenceResponse(
+                        error=pb_utils.TritonError(
+                            "STREAM only supported in decoupled mode"
+                        )
+                    )
+                )
+            else:
+                out_tensor = pb_utils.Tensor(
+                    "text_output", np.repeat(input_np, rep_count, axis=1)
+                )
+                responses.append(pb_utils.InferenceResponse([out_tensor]))
+        return responses
+
+    def exec_decoupled(self, requests):
+        for request in requests:
+            params = json.loads(request.parameters())
+            rep_count = params["REPETITION"] if "REPETITION" in params else 1
+            fail_last = params["FAIL_LAST"] if "FAIL_LAST" in params else False
+            delay = params["DELAY"] if "DELAY" in params else None
+
+            sender = request.get_response_sender()
+            input_np = pb_utils.get_input_tensor_by_name(
+                request, "text_input"
+            ).as_numpy()
+            stream_np = pb_utils.get_input_tensor_by_name(request, "stream").as_numpy()
+            out_tensor = pb_utils.Tensor("text_output", input_np)
+            response = pb_utils.InferenceResponse([out_tensor])
+            # If stream enabled, just send multiple copies of response
+            # FIXME: Could split up response string into tokens, but this is simpler for now.
+            stream = stream_np.flatten()[0]
+            if stream:
+                for _ in range(rep_count):
+                    if delay is not None:
+                        time.sleep(delay)
+                    sender.send(response)
+                sender.send(
+                    None
+                    if not fail_last
+                    else pb_utils.InferenceResponse(
+                        error=pb_utils.TritonError("An Error Occurred")
+                    ),
+                    flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL,
+                )
+            # If stream disabled, just send one response
+            else:
+                sender.send(
+                    response, flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
+                )
+        return None

--- a/Til/vLLM-server/triton_data/tests/test_models/mock_llm/config.pbtxt
+++ b/Til/vLLM-server/triton_data/tests/test_models/mock_llm/config.pbtxt
@@ -1,0 +1,60 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+backend: "python"
+
+max_batch_size: 0
+
+model_transaction_policy {
+  decoupled: True
+}
+
+input [
+  {
+    name: "text_input"
+    data_type: TYPE_STRING
+    dims: [ 1, 1 ]
+  },
+  {
+    name: "stream"
+    data_type: TYPE_BOOL
+    dims: [ 1, 1 ]
+  }
+]
+
+output [
+  {
+    name: "text_output"
+    data_type: TYPE_STRING
+    dims: [ 1, -1 ]
+  }
+]
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_MODEL
+  }
+]

--- a/Til/vLLM-server/triton_data/tests/test_observability.py
+++ b/Til/vLLM-server/triton_data/tests/test_observability.py
@@ -1,0 +1,90 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from tests.utils import setup_fastapi_app, setup_server
+
+
+# Override conftest.py default model
+@pytest.fixture
+def model():
+    return "mock_llm"
+
+
+class TestObservability:
+    @pytest.fixture(scope="class")
+    def client(self):
+        # TODO: Cleanup, mock server/engine, etc.
+        model_repository = Path(__file__).parent / "test_models"
+        server = setup_server(str(model_repository))
+        app = setup_fastapi_app(tokenizer="", server=server, backend=None)
+        with TestClient(app) as test_client:
+            yield test_client
+
+        server.stop()
+
+    ### General Error Handling ###
+    def test_not_found(self, client):
+        response = client.get("/does-not-exist")
+        assert response.status_code == 404
+
+    ### Startup / Health ###
+    def test_startup_success(self, client):
+        response = client.get("/health/ready")
+        assert response.status_code == 200
+
+    ### Metrics ###
+    def test_startup_metrics(self, client):
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        # TODO: Flesh out metrics tests further
+        assert "nv_cpu_utilization" in response.text
+
+    ### Models ###
+    def test_models_list(self, client):
+        response = client.get("/v1/models")
+        assert response.status_code == 200
+        models = response.json()["data"]
+        # Two models are in test_models specifically to verify that all models
+        # are listed by this endpoint. This can be removed if the behavior changes.
+        assert len(models) == 2
+        for model in models:
+            assert model["id"]
+            assert model["object"] == "model"
+            assert model["created"] > 0
+            assert model["owned_by"] == "Triton Inference Server"
+
+    def test_models_get(self, client, model):
+        response = client.get(f"/v1/models/{model}")
+        assert response.status_code == 200
+        model_resp = response.json()
+        assert model_resp["id"] == model
+        assert model_resp["object"] == "model"
+        assert model_resp["created"] > 0
+        assert model_resp["owned_by"] == "Triton Inference Server"

--- a/Til/vLLM-server/triton_data/tests/test_openai_client.py
+++ b/Til/vLLM-server/triton_data/tests/test_openai_client.py
@@ -1,0 +1,247 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List
+
+import openai
+import pytest
+
+
+@pytest.mark.openai
+class TestOpenAIClient:
+    @pytest.fixture(scope="class")
+    def client(self, server):
+        return server.get_client()
+
+    def test_openai_client_models(self, client: openai.OpenAI, backend: str):
+        models = list(client.models.list())
+        print(f"Models: {models}")
+        if backend == "tensorrtllm":
+            # tensorrt_llm_bls +
+            # preprocess -> tensorrt_llm -> postprocess
+            assert len(models) == 4
+        elif backend == "vllm":
+            assert len(models) == 1
+        else:
+            raise Exception(f"Unexpected backend {backend=}")
+
+    def test_openai_client_completion(
+        self, client: openai.OpenAI, model: str, prompt: str
+    ):
+        completion = client.completions.create(
+            prompt=prompt,
+            model=model,
+        )
+
+        print(f"Completion results: {completion}")
+        assert completion.choices[0].text
+        assert completion.choices[0].finish_reason == "stop"
+
+    def test_openai_client_chat_completion(
+        self, client: openai.OpenAI, model: str, messages: List[dict]
+    ):
+        chat_completion = client.chat.completions.create(
+            messages=messages,
+            model=model,
+        )
+
+        print(f"Chat completion results: {chat_completion}")
+        assert chat_completion.choices[0].message.content
+        assert chat_completion.choices[0].finish_reason == "stop"
+
+    @pytest.mark.parametrize("echo", [False, True])
+    def test_openai_client_completion_echo(
+        self, client: openai.OpenAI, echo: bool, backend: str, model: str, prompt: str
+    ):
+        if backend == "tensorrtllm":
+            pytest.skip(
+                reason="TRT-LLM backend currently only supports setting this parameter at model load time",
+            )
+
+        completion = client.completions.create(prompt=prompt, model=model, echo=echo)
+
+        print(f"Completion results: {completion}")
+        response = completion.choices[0].text
+        if echo:
+            assert prompt in response
+        else:
+            assert prompt not in response
+
+    @pytest.mark.skip(reason="Not Implemented Yet")
+    def test_openai_client_function_calling(self):
+        pass
+
+
+@pytest.mark.openai
+class TestAsyncOpenAIClient:
+    @pytest.fixture(scope="class")
+    def client(self, server):
+        return server.get_async_client()
+
+    @pytest.mark.asyncio
+    async def test_openai_client_models(self, client: openai.AsyncOpenAI, backend: str):
+        async_models = await client.models.list()
+        models = [model async for model in async_models]
+        print(f"Models: {models}")
+        if backend == "tensorrtllm":
+            # tensorrt_llm_bls +
+            # preprocess -> tensorrt_llm -> postprocess
+            assert len(models) == 4
+        elif backend == "vllm":
+            assert len(models) == 1
+        else:
+            raise Exception(f"Unexpected backend {backend=}")
+
+    @pytest.mark.asyncio
+    async def test_openai_client_completion(
+        self, client: openai.AsyncOpenAI, model: str, prompt: str
+    ):
+        completion = await client.completions.create(
+            prompt=prompt,
+            model=model,
+        )
+
+        print(f"Completion results: {completion}")
+        assert completion.choices[0].text
+        assert completion.choices[0].finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_openai_client_chat_completion(
+        self, client: openai.AsyncOpenAI, model: str, messages: List[dict]
+    ):
+        chat_completion = await client.chat.completions.create(
+            messages=messages,
+            model=model,
+        )
+
+        assert chat_completion.choices[0].message.content
+        assert chat_completion.choices[0].finish_reason == "stop"
+        print(f"Chat completion results: {chat_completion}")
+
+    @pytest.mark.asyncio
+    async def test_completion_streaming(
+        self, client: openai.AsyncOpenAI, model: str, prompt: str
+    ):
+        # Test single completion for comparison
+        chat_completion = await client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=10,
+            temperature=0.0,
+            stream=False,
+        )
+        output = chat_completion.choices[0].text
+        stop_reason = chat_completion.choices[0].finish_reason
+
+        # Test streaming
+        stream = await client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=10,
+            temperature=0.0,
+            stream=True,
+        )
+        chunks = []
+        finish_reason_count = 0
+        async for chunk in stream:
+            delta = chunk.choices[0]
+            if delta.text:
+                chunks.append(delta.text)
+            if delta.finish_reason is not None:
+                finish_reason_count += 1
+
+        # finish reason should only return in last block
+        assert finish_reason_count == 1
+        assert chunk.choices[0].finish_reason == stop_reason
+        assert "".join(chunks) == output
+
+    @pytest.mark.parametrize(
+        "sampling_parameter_dict",
+        [
+            {},
+            # Verify that stop words work with streaming outputs
+            {"stop": "is"},
+            {"stop": ["is"]},
+            {"stop": ["is", ".", ","]},
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_chat_streaming(
+        self,
+        client: openai.AsyncOpenAI,
+        model: str,
+        messages: List[dict],
+        sampling_parameter_dict: dict,
+    ):
+        # Fixed seed and temperature for comparing reproducible responses
+        seed = 0
+        temperature = 0.0
+        # Generate enough tokens to easily identify stop words are working.
+        max_tokens = 64
+
+        # Test single chat completion for comparison
+        chat_completion = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            seed=seed,
+            stream=False,
+            **sampling_parameter_dict,
+        )
+        output = chat_completion.choices[0].message.content
+        stop_reason = chat_completion.choices[0].finish_reason
+
+        # Test streaming
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            seed=seed,
+            stream=True,
+            **sampling_parameter_dict,
+        )
+        chunks = []
+        finish_reason_count = 0
+        async for chunk in stream:
+            delta = chunk.choices[0].delta
+            if delta.role:
+                assert delta.role == "assistant"
+            if delta.content:
+                chunks.append(delta.content)
+            if chunk.choices[0].finish_reason is not None:
+                finish_reason_count += 1
+
+        # finish reason should only return in last block
+        assert finish_reason_count == 1
+        assert chunk.choices[0].finish_reason == stop_reason
+
+        # Assert that streaming actually returned multiple responses
+        # and that it is equivalent to the non-streamed output
+        assert len(chunks) > 1
+        streamed_output = "".join(chunks)
+        assert streamed_output == output

--- a/Til/vLLM-server/triton_data/tests/test_tool_calling.py
+++ b/Til/vLLM-server/triton_data/tests/test_tool_calling.py
@@ -1,0 +1,592 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+import os
+from typing import Dict, List, Optional
+
+import openai
+import pytest
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+    ChatCompletionMessageToolCall,
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionToolParam,
+)
+
+# resources for testing the tool callings
+WEATHER_TOOL: ChatCompletionToolParam = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "The city to find the weather for, "
+                    "e.g. 'San Francisco'",
+                },
+                "state": {
+                    "type": "string",
+                    "description": "must the two-letter abbreviation for the state "
+                    "that the city is in, e.g. 'CA' which would "
+                    "mean 'California'",
+                },
+                "unit": {
+                    "type": "string",
+                    "description": "The unit to fetch the temperature in",
+                    "enum": ["celsius", "fahrenheit"],
+                },
+            },
+            "required": ["city", "state", "unit"],
+        },
+    },
+}
+
+WEATHER_FORECAST_TOOL: ChatCompletionToolParam = {
+    "type": "function",
+    "function": {
+        "name": "get_n_day_weather_forecast",
+        "description": "Get an N-day weather forecast",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "The city to find the weather for, "
+                    "e.g. 'San Francisco'",
+                },
+                "state": {
+                    "type": "string",
+                    "description": "must the two-letter abbreviation for the state "
+                    "that the city is in, e.g. 'CA' which would "
+                    "mean 'California'",
+                },
+                "unit": {
+                    "type": "string",
+                    "description": "The unit to fetch the temperature in",
+                    "enum": ["celsius", "fahrenheit"],
+                },
+                "num_days": {
+                    "type": "integer",
+                    "description": "The number of days to forecast",
+                },
+            },
+            "required": ["city", "state", "unit", "num_days"],
+        },
+    },
+}
+
+MESSAGES_ASKING_FOR_TOOLS: List[ChatCompletionMessageParam] = [
+    {
+        "role": "system",
+        "content": "You're a helpful assistant! Answer the users question best you can.",
+    },
+    {"role": "user", "content": "What is the weather in Dallas, Texas in Fahrenheit?"},
+]
+
+MESSAGES_WITH_TOOL_RESPONSE: List[ChatCompletionMessageParam] = [
+    {
+        "role": "system",
+        "content": "You're a helpful assistant! Answer the users question best you can.",
+    },
+    {"role": "user", "content": "What is the weather in Dallas, Texas in Fahrenheit?"},
+    {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "123456789",
+                "type": "function",
+                "function": {
+                    "name": "get_current_weather",
+                    "arguments": '{"city": "Dallas", "state": "TX", '
+                    '"unit": "fahrenheit"}',
+                },
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "123456789", "content": "98"},
+]
+
+WEATHER_FORECAST_TOOL_CHOICE: ChatCompletionNamedToolChoiceParam = {
+    "function": {"name": "get_n_day_weather_forecast"},
+    "type": "function",
+}
+
+
+@pytest.mark.openai
+class TestAsyncClientToolCalling:
+    @pytest.fixture(scope="class")
+    def client(self, server):
+        return server.get_async_client()
+
+    def validate_tool_calls_present(
+        self, tool_calls: Optional[List[ChatCompletionMessageToolCall]], skip_id=False
+    ):
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].type == "function"
+        assert tool_calls[0].function is not None
+        assert isinstance(tool_calls[0].id, str)
+        if not skip_id:
+            assert len(tool_calls[0].id) >= 9
+
+    def validate_weather_tool_arguments(self, parsed_arguments: Dict):
+        assert isinstance(parsed_arguments, Dict)
+        assert isinstance(parsed_arguments.get("city"), str)
+        assert isinstance(parsed_arguments.get("state"), str)
+        assert isinstance(parsed_arguments.get("unit"), str)
+        assert parsed_arguments.get("city") == "Dallas"
+        assert parsed_arguments.get("state") in ("TX", "Texas")
+        assert parsed_arguments.get("unit") == "fahrenheit"
+
+    def validate_weather_forcast_tool_arguments(self, parsed_arguments: Dict):
+        assert isinstance(parsed_arguments, Dict)
+        assert isinstance(parsed_arguments.get("city"), str)
+        assert isinstance(parsed_arguments.get("state"), str)
+        assert isinstance(parsed_arguments.get("unit"), str)
+        assert isinstance(parsed_arguments.get("num_days"), int)
+        assert parsed_arguments.get("city") == "Dallas"
+        assert parsed_arguments.get("state") in ("TX", "Texas")
+        assert parsed_arguments.get("unit") == "fahrenheit"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_and_choice(self, client: openai.AsyncOpenAI, model: str):
+        chat_completion = await client.chat.completions.create(
+            messages=MESSAGES_ASKING_FOR_TOOLS,
+            temperature=0,
+            max_tokens=128,
+            model=model,
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+        )
+
+        choice = chat_completion.choices[0]
+        stop_reason = chat_completion.choices[0].finish_reason
+        tool_calls = chat_completion.choices[0].message.tool_calls
+
+        # make sure a tool call is present
+        self.validate_tool_calls_present(tool_calls)
+        assert stop_reason == "tool_calls"
+
+        # make sure the weather tool was called (classic example) with arguments
+        assert tool_calls[0].function.name == WEATHER_TOOL["function"]["name"]
+        assert tool_calls[0].function.arguments is not None
+        assert isinstance(tool_calls[0].function.arguments, str)
+
+        # make sure the arguments parse properly
+        parsed_arguments = json.loads(tool_calls[0].function.arguments)
+        self.validate_weather_tool_arguments(parsed_arguments)
+
+        function_name: Optional[str] = None
+        function_args_str: str = ""
+        tool_call_id: Optional[str] = None
+        role_name: Optional[str] = None
+        finish_reason_count: int = 0
+
+        # make the same request, streaming
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=MESSAGES_ASKING_FOR_TOOLS,
+            temperature=0,
+            max_tokens=128,
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+            stream=True,
+        )
+
+        async for chunk in stream:
+            assert chunk.choices[0].index == 0
+
+            if chunk.choices[0].finish_reason:
+                finish_reason_count += 1
+                assert chunk.choices[0].finish_reason == "tool_calls"
+
+            # if a role is being streamed make sure it wasn't already set to
+            # something else
+            if chunk.choices[0].delta.role:
+                assert not role_name or role_name == "assistant"
+                role_name = "assistant"
+
+            # if a tool call is streamed make sure there's exactly one
+            # (based on the request parameters
+            streamed_tool_calls = chunk.choices[0].delta.tool_calls
+
+            if streamed_tool_calls and len(streamed_tool_calls) > 0:
+                assert len(streamed_tool_calls) == 1
+                tool_call = streamed_tool_calls[0]
+
+                # if a tool call ID is streamed, make sure one hasn't been already
+                if tool_call.id:
+                    assert not tool_call_id
+                    tool_call_id = tool_call.id
+
+                # if parts of the function start being streamed
+                if tool_call.function:
+                    # if the function name is defined, set it. it should be streamed
+                    # IN ENTIRETY, exactly one time.
+                    if tool_call.function.name:
+                        assert function_name is None
+                        assert isinstance(tool_call.function.name, str)
+                        function_name = tool_call.function.name
+                    if tool_call.function.arguments:
+                        assert isinstance(tool_call.function.arguments, str)
+                        function_args_str += tool_call.function.arguments
+
+        assert finish_reason_count == 1
+        assert role_name == "assistant"
+        assert isinstance(tool_call_id, str) and (len(tool_call_id) >= 9)
+
+        # validate the name and arguments
+        assert function_name == WEATHER_TOOL["function"]["name"]
+        assert function_name == tool_calls[0].function.name
+        assert isinstance(function_args_str, str)
+
+        # validate arguments
+        streamed_args = json.loads(function_args_str)
+        self.validate_weather_tool_arguments(streamed_args)
+
+        # make sure everything matches non-streaming except for ID
+        assert function_name == tool_calls[0].function.name
+        assert choice.message.role == role_name
+        assert choice.message.tool_calls[0].function.name == function_name
+
+        # compare streamed with non-streamed args Dict-wise, not string-wise
+        # because character-to-character comparison might not work e.g. the tool
+        # call parser adding extra spaces or something like that. we care about the
+        # dicts matching not byte-wise match
+        assert parsed_arguments == streamed_args
+
+    @pytest.mark.asyncio
+    async def test_tool_call_with_reply_response(
+        self, client: openai.AsyncOpenAI, model: str, backend: str
+    ):
+        chat_completion = await client.chat.completions.create(
+            messages=MESSAGES_WITH_TOOL_RESPONSE,
+            temperature=0,
+            max_tokens=128,
+            model=model,
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+        )
+
+        choice = chat_completion.choices[0]
+
+        assert choice.finish_reason != "tool_calls"  # "stop"
+        assert choice.message.role == "assistant"
+        assert choice.message.tool_calls is None or len(choice.message.tool_calls) == 0
+        assert choice.message.content is not None
+
+        stream = await client.chat.completions.create(
+            messages=MESSAGES_WITH_TOOL_RESPONSE,
+            temperature=0,
+            max_tokens=128,
+            model=model,
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+            stream=True,
+        )
+
+        chunks: List[str] = []
+        finish_reason_count = 0
+        role_sent: bool = False
+
+        async for chunk in stream:
+            delta = chunk.choices[0].delta
+
+            if delta.role:
+                assert not role_sent
+                assert delta.role == "assistant"
+                role_sent = True
+
+            if delta.content:
+                chunks.append(delta.content)
+
+            if chunk.choices[0].finish_reason is not None:
+                finish_reason_count += 1
+                assert chunk.choices[0].finish_reason == choice.finish_reason
+
+            assert not delta.tool_calls or len(delta.tool_calls) == 0
+
+        assert role_sent
+        assert finish_reason_count == 1
+        assert len(chunks)
+
+        # validate if steaming and non-streaming generates the same content
+        assert "".join(chunks) == choice.message.content
+
+    @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") == "TRTLLM",
+        reason="latest release version of Tensorrt LLM 0.18 doesn't support guided decoding",
+    )
+    @pytest.mark.asyncio
+    async def test_tool_call_with_named_tool_choice(
+        self, client: openai.AsyncOpenAI, model: str
+    ):
+        chat_completion = await client.chat.completions.create(
+            messages=MESSAGES_ASKING_FOR_TOOLS,
+            temperature=0,
+            max_tokens=128,
+            model=model,
+            tool_choice=WEATHER_FORECAST_TOOL_CHOICE,
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+        )
+
+        choice = chat_completion.choices[0]
+        stop_reason = chat_completion.choices[0].finish_reason
+        tool_calls = chat_completion.choices[0].message.tool_calls
+
+        # make sure a tool call is present
+        self.validate_tool_calls_present(tool_calls, skip_id=True)
+        assert stop_reason != "tool_calls"
+
+        # make sure the weather tool was called (classic example) with arguments
+        assert tool_calls[0].function.name == WEATHER_FORECAST_TOOL["function"]["name"]
+        assert tool_calls[0].function.arguments is not None
+        assert isinstance(tool_calls[0].function.arguments, str)
+
+        # make sure the arguments parse properly
+        parsed_arguments = json.loads(tool_calls[0].function.arguments)
+        self.validate_weather_forcast_tool_arguments(parsed_arguments)
+
+        function_name: Optional[str] = None
+        function_args_str: str = ""
+        tool_call_id: Optional[str] = None
+        role_name: Optional[str] = None
+        finish_reason_count: int = 0
+
+        # make the same request, streaming
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=MESSAGES_ASKING_FOR_TOOLS,
+            temperature=0,
+            max_tokens=128,
+            tool_choice=WEATHER_FORECAST_TOOL_CHOICE,
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+            stream=True,
+        )
+
+        async for chunk in stream:
+            assert chunk.choices[0].index == 0
+
+            if chunk.choices[0].finish_reason:
+                finish_reason_count += 1
+                assert chunk.choices[0].finish_reason != "tool_calls"
+
+            # if a role is being streamed make sure it wasn't already set to
+            # something else
+            if chunk.choices[0].delta.role:
+                assert not role_name or role_name == "assistant"
+                role_name = "assistant"
+
+            # if a tool call is streamed make sure there's exactly one
+            # (based on the request parameters
+            streamed_tool_calls = chunk.choices[0].delta.tool_calls
+
+            if streamed_tool_calls and len(streamed_tool_calls) > 0:
+                assert len(streamed_tool_calls) == 1
+                tool_call = streamed_tool_calls[0]
+
+                # if a tool call ID is streamed, make sure one hasn't been already
+                if tool_call.id:
+                    assert not tool_call_id
+                    tool_call_id = tool_call.id
+
+                # if parts of the function start being streamed
+                if tool_call.function:
+                    # if the function name is defined, set it. it should be streamed
+                    # IN ENTIRETY, exactly one time.
+                    if tool_call.function.name:
+                        assert isinstance(tool_call.function.name, str)
+                        function_name = tool_call.function.name
+                    if tool_call.function.arguments:
+                        assert isinstance(tool_call.function.arguments, str)
+                        function_args_str += tool_call.function.arguments
+
+        assert finish_reason_count == 1
+        assert role_name == "assistant"
+
+        # validate the name and arguments
+        assert function_name == WEATHER_FORECAST_TOOL["function"]["name"]
+        assert function_name == tool_calls[0].function.name
+        assert isinstance(function_args_str, str)
+
+        # validate arguments
+        streamed_args = json.loads(function_args_str)
+        self.validate_weather_forcast_tool_arguments(streamed_args)
+
+        # make sure everything matches non-streaming except for ID
+        assert function_name == tool_calls[0].function.name
+        assert choice.message.role == role_name
+        assert choice.message.tool_calls[0].function.name == function_name
+
+    @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") == "TRTLLM",
+        reason="latest release version of Tensorrt LLM 0.18 doesn't support guided decoding",
+    )
+    @pytest.mark.asyncio
+    async def test_tool_call_with_required_tool_choice(
+        self, client: openai.AsyncOpenAI, model: str
+    ):
+        chat_completion = await client.chat.completions.create(
+            messages=MESSAGES_ASKING_FOR_TOOLS,
+            temperature=0,
+            max_tokens=128,
+            model=model,
+            tool_choice="required",
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+        )
+
+        choice = chat_completion.choices[0]
+        stop_reason = chat_completion.choices[0].finish_reason
+        tool_calls = chat_completion.choices[0].message.tool_calls
+
+        # make sure a tool call is present
+        self.validate_tool_calls_present(tool_calls, skip_id=True)
+        assert stop_reason != "tool_calls"
+
+        # make sure the weather tool was called (classic example) with arguments
+        assert tool_calls[0].function.name == WEATHER_TOOL["function"]["name"]
+        assert tool_calls[0].function.arguments is not None
+        assert isinstance(tool_calls[0].function.arguments, str)
+
+        # make sure the arguments parse properly
+        parsed_arguments = json.loads(tool_calls[0].function.arguments)
+        self.validate_weather_tool_arguments(parsed_arguments)
+
+        function_name: Optional[str] = None
+        function_args_str: str = ""
+        tool_call_id: Optional[str] = None
+        role_name: Optional[str] = None
+        finish_reason_count: int = 0
+
+        # make the same request, streaming
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=MESSAGES_ASKING_FOR_TOOLS,
+            temperature=0,
+            max_tokens=128,
+            tool_choice="required",
+            tools=[WEATHER_TOOL, WEATHER_FORECAST_TOOL],
+            logprobs=False,
+            stream=True,
+        )
+
+        async for chunk in stream:
+            assert chunk.choices[0].index == 0
+
+            if chunk.choices[0].finish_reason:
+                finish_reason_count += 1
+                assert chunk.choices[0].finish_reason != "tool_calls"
+
+            # if a role is being streamed make sure it wasn't already set to
+            # something else
+            if chunk.choices[0].delta.role:
+                assert not role_name or role_name == "assistant"
+                role_name = "assistant"
+
+            # if a tool call is streamed make sure there's exactly one
+            # (based on the request parameters
+            streamed_tool_calls = chunk.choices[0].delta.tool_calls
+
+            if streamed_tool_calls and len(streamed_tool_calls) > 0:
+                assert len(streamed_tool_calls) == 1
+                tool_call = streamed_tool_calls[0]
+
+                # if a tool call ID is streamed, make sure one hasn't been already
+                if tool_call.id:
+                    assert not tool_call_id
+                    tool_call_id = tool_call.id
+
+                # if parts of the function start being streamed
+                if tool_call.function:
+                    # if the function name is defined, set it. it should be streamed
+                    # IN ENTIRETY, exactly one time.
+                    if tool_call.function.name:
+                        assert isinstance(tool_call.function.name, str)
+                        function_name = tool_call.function.name
+                    if tool_call.function.arguments:
+                        assert isinstance(tool_call.function.arguments, str)
+                        function_args_str += tool_call.function.arguments
+
+        assert finish_reason_count == 1
+        assert role_name == "assistant"
+
+        # validate the name and arguments
+        assert function_name == WEATHER_TOOL["function"]["name"]
+        assert function_name == tool_calls[0].function.name
+        assert isinstance(function_args_str, str)
+
+        # validate arguments
+        streamed_args = json.loads(function_args_str)
+        self.validate_weather_tool_arguments(streamed_args)
+
+        # make sure everything matches non-streaming except for ID
+        assert function_name == tool_calls[0].function.name
+        assert choice.message.role == role_name
+        assert choice.message.tool_calls[0].function.name == function_name
+
+    @pytest.mark.asyncio
+    async def test_inconsistent_tool_choice_and_tools(
+        self, client: openai.AsyncOpenAI, model: str
+    ):
+        # tool choice function but the tools are empty
+        with pytest.raises(openai.BadRequestError):
+            await client.chat.completions.create(
+                messages=MESSAGES_ASKING_FOR_TOOLS,
+                temperature=0,
+                max_tokens=128,
+                model=model,
+                tool_choice=WEATHER_FORECAST_TOOL_CHOICE,
+                logprobs=False,
+            )
+        # tool choice function that is not provided in the tools
+        with pytest.raises(openai.BadRequestError):
+            await client.chat.completions.create(
+                messages=MESSAGES_ASKING_FOR_TOOLS,
+                temperature=0,
+                max_tokens=128,
+                model=model,
+                tool_choice=WEATHER_FORECAST_TOOL_CHOICE,
+                tools=[WEATHER_TOOL],
+                logprobs=False,
+            )
+
+        # tool choice required but tools is empty
+        with pytest.raises(openai.BadRequestError):
+            await client.chat.completions.create(
+                messages=MESSAGES_ASKING_FOR_TOOLS,
+                temperature=0,
+                max_tokens=128,
+                model=model,
+                tool_choice="required",
+                tools=[],
+                logprobs=False,
+            )

--- a/Til/vLLM-server/triton_data/tests/utils.py
+++ b/Til/vLLM-server/triton_data/tests/utils.py
@@ -1,0 +1,139 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import openai
+import requests
+import tritonserver
+
+sys.path.append(os.path.join(Path(__file__).resolve().parent, "..", "openai_frontend"))
+from engine.triton_engine import TritonLLMEngine
+from frontend.fastapi_frontend import FastApiFrontend
+
+
+# TODO: Cleanup, refactor, mock, etc.
+def setup_server(model_repository: str):
+    server: tritonserver.Server = tritonserver.Server(
+        model_repository=model_repository,
+        log_verbose=0,
+        log_info=True,
+        log_warn=True,
+        log_error=True,
+    ).start(wait_until_ready=True)
+    return server
+
+
+def setup_fastapi_app(tokenizer: str, server: tritonserver.Server, backend: str):
+    engine: TritonLLMEngine = TritonLLMEngine(
+        server=server, tokenizer=tokenizer, backend=backend
+    )
+    frontend: FastApiFrontend = FastApiFrontend(engine=engine)
+    return frontend.app
+
+
+# Heavily inspired by vLLM's test infrastructure
+class OpenAIServer:
+    API_KEY = "EMPTY"  # Triton's OpenAI server does not need API key
+    START_TIMEOUT = 240  # wait for server to start for up to 240 seconds, mistral model takes longer time to start
+
+    def __init__(
+        self,
+        cli_args: List[str],
+        *,
+        env_dict: Optional[Dict[str, str]] = None,
+    ) -> None:
+        # TODO: Incorporate caller's cli_args passed to this instance instead
+        self.host = "localhost"
+        self.port = 9000
+
+        env = os.environ.copy()
+        if env_dict is not None:
+            env.update(env_dict)
+
+        this_dir = Path(__file__).resolve().parent
+        script_path = this_dir / ".." / "openai_frontend" / "main.py"
+        self.proc = subprocess.Popen(
+            ["python3", script_path] + cli_args,
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        # Wait until health endpoint is responsive
+        self._wait_for_server(
+            url=self.url_for("health", "ready"), timeout=self.START_TIMEOUT
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.proc.terminate()
+        try:
+            wait_secs = 30
+            self.proc.wait(wait_secs)
+        except subprocess.TimeoutExpired:
+            # force kill if needed
+            self.proc.kill()
+
+    def _wait_for_server(self, *, url: str, timeout: float):
+        start = time.time()
+        while True:
+            try:
+                if requests.get(url).status_code == 200:
+                    break
+            except Exception as err:
+                result = self.proc.poll()
+                if result is not None and result != 0:
+                    raise RuntimeError("Server exited unexpectedly.") from err
+
+                time.sleep(0.5)
+                if time.time() - start > timeout:
+                    raise RuntimeError("Server failed to start in time.") from err
+
+    @property
+    def url_root(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def url_for(self, *parts: str) -> str:
+        return self.url_root + "/" + "/".join(parts)
+
+    def get_client(self):
+        return openai.OpenAI(
+            base_url=self.url_for("v1"),
+            api_key=self.API_KEY,
+        )
+
+    def get_async_client(self):
+        return openai.AsyncOpenAI(
+            base_url=self.url_for("v1"),
+            api_key=self.API_KEY,
+        )

--- a/Til/vLLM-server/triton_data/tests/vllm_mistral_models/mistral-nemo-instruct-2407/1/model.json
+++ b/Til/vLLM-server/triton_data/tests/vllm_mistral_models/mistral-nemo-instruct-2407/1/model.json
@@ -1,0 +1,1 @@
+{"model": "mistralai/Mistral-Nemo-Instruct-2407", "disable_log_requests": true, "gpu_memory_utilization": 0.9}

--- a/Til/vLLM-server/triton_data/tests/vllm_mistral_models/mistral-nemo-instruct-2407/config.pbtxt
+++ b/Til/vLLM-server/triton_data/tests/vllm_mistral_models/mistral-nemo-instruct-2407/config.pbtxt
@@ -1,0 +1,28 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+backend: "vllm"
+instance_group [{kind: KIND_MODEL}]

--- a/Til/vLLM-server/triton_data/tests/vllm_models/gemma-3-4b-it/1/model.json
+++ b/Til/vLLM-server/triton_data/tests/vllm_models/gemma-3-4b-it/1/model.json
@@ -1,0 +1,8 @@
+{
+    "model": "google/gemma-3-4b-it",
+    "disable_log_requests": true,
+    "gpu_memory_utilization": 0.6,
+    "max_model_len": 8192,
+    "max_num_seqs": 8,
+    "max_num_batched_tokens": 8192
+  }

--- a/Til/vLLM-server/triton_data/tests/vllm_models/gemma-3-4b-it/config.pbtxt
+++ b/Til/vLLM-server/triton_data/tests/vllm_models/gemma-3-4b-it/config.pbtxt
@@ -1,0 +1,28 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+backend: "vllm"
+instance_group [{kind: KIND_MODEL}]

--- a/Til/vLLM-server/vLLM-Gemma-compose.yaml
+++ b/Til/vLLM-server/vLLM-Gemma-compose.yaml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  vllm_gemma3_4b:
+    image: vllm/vllm-openai
+    ports:
+      - "8002:8002"
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HUGGINGFACE_TOKEN}
+    # volumes:
+    #   - /home/a01088415234/models/gemma-3-4b-it:/models/gemma
+    command: >
+      --model google/gemma-3-4b-it
+      --port 8002
+      --gpu-memory-utilization 0.95
+      --max-model-len 8192
+      --max-num-seqs 10
+      --max-num-batched-tokens 4096
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]

--- a/Til/vLLM-server/vLLM-compose.yaml
+++ b/Til/vLLM-server/vLLM-compose.yaml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  vllm:
+    image: vllm/vllm-openai
+    ports:
+      - "8001:8001"
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HUGGINGFACE_TOKEN}
+    # volumes:
+    #   - /home/a01088415234/models/gemma-3-4b-it:/models/gemma
+    command: >
+      --model google/gemma-3-4b-it
+      --port 8001
+      --gpu-memory-utilization 0.8
+      --max-model-len 4096
+      --max-num-seqs 50
+      --max-num-batched-tokens 4096
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]

--- a/Til/vLLM-server/vLLM-qwen2.5-compose.yaml
+++ b/Til/vLLM-server/vLLM-qwen2.5-compose.yaml
@@ -1,19 +1,15 @@
 version: "3"
 services:
-  vllm:
+  vllm_qwen2.5_coder:
     image: vllm/vllm-openai
     ports:
       - "8001:8001"
-    environment:
-      - HUGGING_FACE_HUB_TOKEN=${HUGGINGFACE_TOKEN}
-    # volumes:
-    #   - /home/a01088415234/models/gemma-3-4b-it:/models/gemma
     command: >
-      --model google/gemma-3-4b-it
+      --model Qwen/Qwen2.5-Coder-3B-Instruct-GPTQ-Int8
       --port 8001
-      --gpu-memory-utilization 0.8
+      --gpu-memory-utilization 0.3
       --max-model-len 4096
-      --max-num-seqs 50
+      --max-num-seqs 10
       --max-num-batched-tokens 4096
     deploy:
       resources:


### PR DESCRIPTION
## 주요 변경 사항
1. Triton Inference Server용 model_repository 디렉토리 생성

2. config.pbtxt 템플릿 예시 추가 (vLLM / Python backend 호환)

3. OpenAI API 요청 처리용 디렉토리 /opt/tritonserver/python/openai/ 경로 지정

4. huggingface token 전달 환경 변수 HF_TOKEN 대응

5. Docker 실행 시 필요한 볼륨 마운트 경로 명시 (.cache, 모델 디렉토리 등)