### PR TITLE
fix: Interview Qdrant collection name

### DIFF
--- a/Integration/app/nodes/interview_langgraph_nodes.py
+++ b/Integration/app/nodes/interview_langgraph_nodes.py
@@ -68,7 +68,7 @@ class QAFlow:
             query_vector = self.embed_text(query)
 
             results = self.qdrant.search(
-                collection_name="knowledge_all",
+                collection_name="tavily_docs",
                 query_vector=query_vector,
                 limit=1,
                 with_payload=True


### PR DESCRIPTION
### 수정 내용:
1. Qdrant 벡터 디비 컬렉션 이름 변경(knowledge all -> tavily_docs) 